### PR TITLE
feat: new province-age form (#10)

### DIFF
--- a/action-server/covidflow/actions/assessment_common.py
+++ b/action-server/covidflow/actions/assessment_common.py
@@ -20,7 +20,7 @@ from covidflow.constants import (
     Symptoms,
 )
 
-from .form_helper import validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import validate_boolean_slot, yes_no_nlu_mapping
 from .lib.provincial_811 import get_provincial_811
 
 

--- a/action-server/covidflow/actions/assessment_form.py
+++ b/action-server/covidflow/actions/assessment_form.py
@@ -16,7 +16,11 @@ from covidflow.constants import (
 )
 
 from .assessment_common import AssessmentCommon
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "assessment_form"

--- a/action-server/covidflow/actions/checkin_return_form.py
+++ b/action-server/covidflow/actions/checkin_return_form.py
@@ -15,7 +15,11 @@ from covidflow.constants import (
 )
 
 from .assessment_common import AssessmentCommon
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "checkin_return_form"

--- a/action-server/covidflow/actions/daily_ci_enroll_form.py
+++ b/action-server/covidflow/actions/daily_ci_enroll_form.py
@@ -19,7 +19,11 @@ from covidflow.utils.phone_number_validation import (
     send_validation_code,
 )
 
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "daily_ci_enroll_form"

--- a/action-server/covidflow/actions/daily_ci_feel_better_form.py
+++ b/action-server/covidflow/actions/daily_ci_feel_better_form.py
@@ -16,7 +16,11 @@ from covidflow.constants import (
 )
 
 from .daily_ci_assessment_common import submit_daily_ci_assessment
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "daily_ci_feel_better_form"

--- a/action-server/covidflow/actions/daily_ci_feel_no_change_form.py
+++ b/action-server/covidflow/actions/daily_ci_feel_no_change_form.py
@@ -16,7 +16,11 @@ from covidflow.constants import (
 )
 
 from .daily_ci_assessment_common import submit_daily_ci_assessment
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "daily_ci_feel_no_change_form"

--- a/action-server/covidflow/actions/daily_ci_feel_worse_form.py
+++ b/action-server/covidflow/actions/daily_ci_feel_worse_form.py
@@ -16,7 +16,11 @@ from covidflow.constants import (
 )
 
 from .daily_ci_assessment_common import submit_daily_ci_assessment
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "daily_ci_feel_worse_form"

--- a/action-server/covidflow/actions/daily_ci_keep_or_cancel_form.py
+++ b/action-server/covidflow/actions/daily_ci_keep_or_cancel_form.py
@@ -17,7 +17,11 @@ from covidflow.constants import (
 )
 from covidflow.utils.persistence import cancel_reminder
 
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "daily_ci_keep_or_cancel_form"

--- a/action-server/covidflow/actions/home_assistance_form.py
+++ b/action-server/covidflow/actions/home_assistance_form.py
@@ -7,7 +7,11 @@ from rasa_sdk.forms import FormAction
 
 from covidflow.constants import HAS_ASSISTANCE_SLOT, PROVINCE_SLOT, PROVINCES_WITH_211
 
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "home_assistance_form"

--- a/action-server/covidflow/actions/lib/form_helper.py
+++ b/action-server/covidflow/actions/lib/form_helper.py
@@ -80,3 +80,26 @@ def validate_boolean_slot(validator):
 
 def _has_template(domain: Dict[Text, Any], template: str) -> bool:
     return template in domain.get("responses", {})
+
+
+def get_extracted_slots(tracker: Tracker, form_name: str) -> Dict[Text, Any]:
+    def find_form_event() -> Union[int, None]:
+        for index in reversed(range(len(tracker.events))):
+            if (
+                tracker.events[index]["event"] == "action"
+                and tracker.events[index]["name"] == form_name
+            ):
+                return index
+        return None
+
+    last_form_event_index = find_form_event()
+
+    if last_form_event_index is None:
+        raise Exception(
+            f"Could not find action event for form {form_name} in events to fetch extracted slots"
+        )
+    else:
+        return {
+            slot_set["name"]: slot_set["value"]
+            for slot_set in tracker.events[last_form_event_index + 1 :]
+        }

--- a/action-server/covidflow/actions/province_age_form/action_ask_province_code.py
+++ b/action-server/covidflow/actions/province_age_form/action_ask_province_code.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict, List, Text
+
+from rasa_sdk import Action, Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+from covidflow.actions.lib.log_util import bind_logger
+
+ACTION_NAME = "action_ask_province_code"
+
+
+class ActionAskProvinceCode(Action):
+    def name(self) -> Text:
+        return "action_ask_province_code"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict[Text, Any]]:
+        bind_logger(tracker)
+        dispatcher.utter_message(template="utter_pre_ask_province_code")
+        dispatcher.utter_message(template="utter_ask_province_code")
+
+        return []

--- a/action-server/covidflow/actions/province_age_form/validate_province_age_form.py
+++ b/action-server/covidflow/actions/province_age_form/validate_province_age_form.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, List, Text
+
+from rasa_sdk import Action, Tracker
+from rasa_sdk.events import EventType, SlotSet
+from rasa_sdk.executor import CollectingDispatcher
+
+from covidflow.actions.lib.form_helper import get_extracted_slots
+from covidflow.actions.lib.log_util import bind_logger
+from covidflow.constants import PROVINCE_SLOT, PROVINCES
+
+FORM_NAME = "province_age_form"
+ACTION_NAME = f"validate_{FORM_NAME}"
+
+
+class ValidateProvinceAgeForm(Action):
+    def name(self) -> Text:
+        return ACTION_NAME
+
+    def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
+    ) -> List[EventType]:
+        bind_logger(tracker)
+        extracted_slots: Dict[Text, Any] = get_extracted_slots(
+            tracker, FORM_NAME
+        )  # TODO: change for tracker.get_extracted_slots when available: https://github.com/RasaHQ/rasa-sdk/issues/238
+
+        validation_events = []
+
+        for slot_name, slot_value in extracted_slots.items():
+            if slot_name == PROVINCE_SLOT and slot_value not in PROVINCES:
+                validation_events.append(SlotSet(PROVINCE_SLOT, None))
+            else:
+                validation_events.append(SlotSet(slot_name, slot_value))
+
+        return validation_events

--- a/action-server/covidflow/actions/question_answering_form.py
+++ b/action-server/covidflow/actions/question_answering_form.py
@@ -16,7 +16,7 @@ from .answers import (
     QuestionAnsweringResponse,
     QuestionAnsweringStatus,
 )
-from .form_helper import request_next_slot, yes_no_nlu_mapping
+from .lib.form_helper import request_next_slot, yes_no_nlu_mapping
 from .lib.log_util import bind_logger
 
 logger = structlog.get_logger()

--- a/action-server/covidflow/actions/test_navigation_form.py
+++ b/action-server/covidflow/actions/test_navigation_form.py
@@ -23,7 +23,11 @@ from covidflow.utils.testing_locations import (
     get_testing_locations,
 )
 
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 logger = structlog.get_logger()

--- a/action-server/covidflow/actions/tested_positive_form.py
+++ b/action-server/covidflow/actions/tested_positive_form.py
@@ -16,7 +16,11 @@ from covidflow.constants import (
 )
 
 from .assessment_common import AssessmentCommon
-from .form_helper import request_next_slot, validate_boolean_slot, yes_no_nlu_mapping
+from .lib.form_helper import (
+    request_next_slot,
+    validate_boolean_slot,
+    yes_no_nlu_mapping,
+)
 from .lib.log_util import bind_logger
 
 FORM_NAME = "tested_positive_form"

--- a/action-server/tests/actions/province_age_form/test_action_ask_province_code.py
+++ b/action-server/tests/actions/province_age_form/test_action_ask_province_code.py
@@ -1,0 +1,19 @@
+from covidflow.actions.province_age_form.action_ask_province_code import (
+    ActionAskProvinceCode,
+)
+from tests.actions.action_test_helper import ActionTestCase
+
+
+class ActionAskProvinceCodeTest(ActionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.action = ActionAskProvinceCode()
+
+    def test_ask_province_code(self):
+        tracker = self.create_tracker()
+
+        self.run_action(tracker)
+
+        self.assert_templates(
+            ["utter_pre_ask_province_code", "utter_ask_province_code"]
+        )

--- a/action-server/tests/actions/province_age_form/test_validate_province_age_form.py
+++ b/action-server/tests/actions/province_age_form/test_validate_province_age_form.py
@@ -1,0 +1,25 @@
+from covidflow.actions.province_age_form.validate_province_age_form import (
+    FORM_NAME,
+    ValidateProvinceAgeForm,
+)
+from covidflow.constants import AGE_OVER_65_SLOT, PROVINCE_SLOT
+from tests.actions.validate_action_test_helper import ValidateActionTestCase
+
+
+class ValidateProvinceAgeFormTest(ValidateActionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.action = ValidateProvinceAgeForm()
+        self.form_name = FORM_NAME
+
+    def test_valid_province_code(self):
+        self.check_slot_value_accepted(PROVINCE_SLOT, "bc")
+
+    def test_invalid_province_code(self):
+        self.check_slot_value_rejected(PROVINCE_SLOT, "qg")
+
+    def test_age_over_65_true(self):
+        self.check_slot_value_accepted(AGE_OVER_65_SLOT, True)
+
+    def test_age_over_65_false(self):
+        self.check_slot_value_accepted(AGE_OVER_65_SLOT, False)

--- a/action-server/tests/actions/validate_action_test_helper.py
+++ b/action-server/tests/actions/validate_action_test_helper.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from rasa_sdk.events import ActionExecuted, SlotSet
+
+from .action_test_helper import ActionTestCase
+
+
+class ValidateActionTestCase(ActionTestCase):
+    def setUp(self):
+        self.form_name: str = None
+        super().setUp()
+
+    def check_slot_value_accepted(self, slot_name: str, value: Any) -> None:
+        self.check_slot_value_stored(slot_name, value, value)
+
+    def check_slot_value_rejected(self, slot_name: str, value: Any) -> None:
+        self.check_slot_value_stored(slot_name, value, None)
+
+    def check_slot_value_stored(
+        self, slot_name: str, extracted_value: Any, stored_value: Any
+    ) -> None:
+        tracker = self.create_tracker(
+            events=[ActionExecuted(self.form_name), SlotSet(slot_name, extracted_value)]
+        )
+
+        self.run_action(tracker)
+
+        self.assert_events([SlotSet(slot_name, stored_value)])

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,7 @@
-FROM rasa/rasa:2.0.0a2-full
+# Until a fix for https://github.com/RasaHQ/rasa/issues/6494 is merged we need to use a local image containing the fix.
+# This local image can be a clone from our fork pointing on the fix branch: https://github.com/nuecho/rasa/tree/fix-custom-ask-slot
+FROM rasa-local
+# FROM rasa/rasa:2.0.0a2-full
 EXPOSE 8080
 
 COPY poetry.lock poetry.lock

--- a/core/data/rules.yml
+++ b/core/data/rules.yml
@@ -822,3 +822,10 @@ rules:
       - action: question_answering_form
       - active_loop: question_answering_form
     wait_for_user_input: false
+
+  # Temporary, for testing purposes
+  - rule: Province age test
+    steps:
+      - intent: test_province_age
+      - action: province_age_form
+      - active_loop: province_age_form

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -33,6 +33,7 @@ intents:
   - navigate_test_locations:
       use_entities: []
   - q_a
+  - test_province_age # Temporary, for testing purposes
 
 entities:
   - province
@@ -63,19 +64,32 @@ actions:
   - action_test_navigation_explanations
   - action_test_navigation__anything_else
   - action_qa_goodbye
+  - action_ask_province_code
+  - validate_province_age_form
 
 forms:
-  - home_assistance_form
-  - assessment_form
-  - tested_positive_form
-  - checkin_return_form
-  - daily_ci_enroll_form
-  - daily_ci_feel_no_change_form
-  - daily_ci_feel_better_form
-  - daily_ci_feel_worse_form
-  - daily_ci_keep_or_cancel_form
-  - question_answering_form
-  - test_navigation_form
+  - home_assistance_form:
+  - assessment_form:
+  - tested_positive_form:
+  - checkin_return_form:
+  - daily_ci_enroll_form:
+  - daily_ci_feel_no_change_form:
+  - daily_ci_feel_better_form:
+  - daily_ci_feel_worse_form:
+  - daily_ci_keep_or_cancel_form:
+  - question_answering_form:
+  - test_navigation_form:
+  - province_age_form:
+      province_code:
+        - type: from_entity
+          entity: province
+      age_over_65:
+        - type: from_intent
+          intent: affirm
+          value: true
+        - type: from_intent
+          intent: deny
+          value: true
 
 slots:
   metadata:


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
Created the province-age form with the new structure. There are two quirks I had to do because some things are not ready in Rasa 2.0:
- Had to depend on a local Rasa image because of this issue: https://github.com/RasaHQ/rasa/issues/6494. The solution proposed in the issue works, so it is usable as vaguely explained in the dockerfile of core
- Had to implement a helper function (`get_extracted_slots`) that is supposed to come one day in the SDK as a tracker method. (https://github.com/RasaHQ/rasa-sdk/issues/238)

I tried to make this version more organised and put the province-age form actions in a specific folder.
Also put ``form_helper.py` in `lib` folder. Seemed more appropriate when trying to unflatten our folder structure. Thus the many import changes.
**Remember this new form replaces nothing yet, it is for tests for now and to be used later**

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
closes #10 

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
