### PR TITLE
feat: new question answering form (#33)

### DIFF
--- a/action-server/covidflow/actions/question_answering_form.py
+++ b/action-server/covidflow/actions/question_answering_form.py
@@ -89,7 +89,7 @@ class ActionAskActiveQuestion(Action):
 
         events = []
 
-        if tracker.get_slot(SKIP_QA_INTRO_SLOT) != True:
+        if not (tracker.get_slot(SKIP_QA_INTRO_SLOT) is True):
 
             dispatcher.utter_message(template="utter_can_help_with_questions")
             dispatcher.utter_message(template="utter_qa_disclaimer")
@@ -141,9 +141,7 @@ class ValidateQuestionAnsweringForm(Action):
 
                 slot_events += [SlotSet(STATUS_SLOT, result.status)]
 
-                if (
-                    result.status == QuestionAnsweringStatus.SUCCESS and result.answers
-                ):  # not sure about this. Shouldn't happen
+                if result.status == QuestionAnsweringStatus.SUCCESS:
                     dispatcher.utter_message(result.answers[0])
                     slot_events += [SlotSet(ANSWERS_SLOT, result.answers)]
                 else:

--- a/action-server/covidflow/actions/question_answering_form.py
+++ b/action-server/covidflow/actions/question_answering_form.py
@@ -1,26 +1,19 @@
 import os
 import random
-from typing import Any, Dict, List, Optional, Text, Union
+from typing import Any, Dict, List, Text
 
 import structlog
 from aiohttp import ClientSession
-from rasa_sdk import Tracker
-from rasa_sdk.events import (
-    ActionExecuted,
-    ActiveLoop,
-    BotUttered,
-    EventType,
-    SlotSet,
-    UserUttered,
-)
+from rasa_sdk import Action, Tracker
+from rasa_sdk.events import ActionExecuted, BotUttered, EventType, SlotSet, UserUttered
 from rasa_sdk.executor import CollectingDispatcher
-from rasa_sdk.forms import REQUESTED_SLOT, FormAction
+from rasa_sdk.forms import REQUESTED_SLOT
 
 from covidflow.constants import (
     ACTION_LISTEN_NAME,
-    FALLBACK_INTENT,
     LANGUAGE_SLOT,
     QA_TEST_PROFILE_ATTRIBUTE,
+    SKIP_SLOT_PLACEHOLDER,
 )
 
 from .answers import (
@@ -28,8 +21,7 @@ from .answers import (
     QuestionAnsweringResponse,
     QuestionAnsweringStatus,
 )
-from .lib.action_utils import get_intent
-from .lib.form_helper import request_next_slot, yes_no_nlu_mapping
+from .lib.form_helper import _form_slots_to_validate
 from .lib.log_util import bind_logger
 
 logger = structlog.get_logger()
@@ -52,6 +44,10 @@ QUESTION_KEY = "question"
 FEEDBACK_NOT_GIVEN = "not_given"
 
 FORM_NAME = "question_answering_form"
+ASK_QUESTION_ACTION_NAME = f"action_ask_{QUESTION_SLOT}"
+VALIDATE_ACTION_NAME = f"validate_{FORM_NAME}"
+SUBMIT_ACTION_NAME = f"action_submit_question_answering_form"
+FALLBACK_ACTIVATE_ACTION_NAME = "action_activate_fallback_question_answering_form"
 
 TEST_PROFILES_RESPONSE = {
     "success": QuestionAnsweringResponse(
@@ -67,128 +63,109 @@ TEST_PROFILES_RESPONSE = {
 }
 
 
-class QuestionAnsweringForm(FormAction):
+class ActionActivateFallbackQuestionAnswering(Action):
     def name(self) -> Text:
-
-        return FORM_NAME
+        return FALLBACK_ACTIVATE_ACTION_NAME
 
     async def run(
-        self, dispatcher, tracker, domain,
-    ):
-        bind_logger(tracker)
-        return await super().run(dispatcher, tracker, domain)
-
-    ## override to play initial messages or prefill slots
-    async def _activate_if_required(
-        self,
-        dispatcher: CollectingDispatcher,
-        tracker: Tracker,
-        domain: Dict[Text, Any],
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[EventType]:
-        if tracker.active_loop.get("name") == FORM_NAME:
-            return await super()._activate_if_required(dispatcher, tracker, domain)
+        bind_logger(tracker)
 
-        intent = get_intent(tracker)
+        question = tracker.latest_message.get("text", "")
 
-        # Fallback QA
-        if intent == FALLBACK_INTENT:
-            question = tracker.latest_message.get("text", "")
+        # Slot will be validated on form activation
+        return [SlotSet(QUESTION_SLOT, question)]
 
-            result = await self.validate_active_question(
-                question, dispatcher, tracker, domain
+
+class ActionAskActiveQuestion(Action):
+    def name(self) -> Text:
+        return ASK_QUESTION_ACTION_NAME
+
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
+    ) -> List[EventType]:
+        bind_logger(tracker)
+
+        events = []
+
+        if tracker.get_slot(SKIP_QA_INTRO_SLOT) != True:
+
+            dispatcher.utter_message(template="utter_can_help_with_questions")
+            dispatcher.utter_message(template="utter_qa_disclaimer")
+
+            random_qa_samples = (
+                _get_fixed_questions_samples()
+                if _must_stub_result(tracker)
+                else _get_random_question_samples(domain)
             )
 
-            return await super()._activate_if_required(dispatcher, tracker, domain) + [
-                SlotSet(QUESTION_SLOT, question),
-                SlotSet(STATUS_SLOT, result[STATUS_SLOT]),
-                SlotSet(ANSWERS_SLOT, result[ANSWERS_SLOT]),
-            ]
+            if len(random_qa_samples) > 0:
+                dispatcher.utter_message(
+                    template="utter_qa_sample",
+                    sample_questions="\n".join(random_qa_samples),
+                )
+            events = [SlotSet(SKIP_QA_INTRO_SLOT, True)]
 
-        # Regular QA
-        # Messages are only played for the first question
-        if tracker.get_slot(SKIP_QA_INTRO_SLOT) == True or intent != "ask_question":
-            return await super()._activate_if_required(dispatcher, tracker, domain)
+        dispatcher.utter_message(template="utter_ask_active_question")
+        return events
 
-        dispatcher.utter_message(template="utter_can_help_with_questions")
-        dispatcher.utter_message(template="utter_qa_disclaimer")
 
-        random_qa_samples = (
-            _get_fixed_questions_samples()
-            if _must_stub_result(tracker)
-            else _get_random_question_samples(domain)
-        )
+class ValidateQuestionAnsweringForm(Action):
+    def name(self) -> Text:
+        return VALIDATE_ACTION_NAME
 
-        if len(random_qa_samples) > 0:
-            dispatcher.utter_message(
-                template="utter_qa_sample",
-                sample_questions="\n".join(random_qa_samples),
-            )
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
+    ) -> List[EventType]:
+        bind_logger(tracker)
 
-        return await super()._activate_if_required(dispatcher, tracker, domain) + [
-            SlotSet(SKIP_QA_INTRO_SLOT, True)
-        ]
+        extracted_slots: Dict[Text, Any] = _form_slots_to_validate(tracker)
 
-    @staticmethod
-    def required_slots(tracker: Tracker) -> List[Text]:
-        status = tracker.get_slot(STATUS_SLOT)
-        if status == QuestionAnsweringStatus.SUCCESS:
-            return [QUESTION_SLOT, FEEDBACK_SLOT]
+        validation_events: List[EventType] = []
 
-        return [QUESTION_SLOT]
+        for slot_name, slot_value in extracted_slots.items():
+            slot_events = [SlotSet(slot_name, slot_value)]
 
-    def slot_mappings(self) -> Dict[Text, Union[Dict, List[Dict]]]:
-        return {
-            QUESTION_SLOT: self.from_text(),
-            FEEDBACK_SLOT: yes_no_nlu_mapping(self),
-        }
+            if slot_name == FEEDBACK_SLOT:
+                if slot_value is False:
+                    dispatcher.utter_message(template="utter_feedback_false")
+                elif not isinstance(slot_value, bool):
+                    slot_events = [SlotSet(FEEDBACK_SLOT, FEEDBACK_NOT_GIVEN)]
+            elif slot_name == QUESTION_SLOT:
+                result = (
+                    _get_stub_qa_result(tracker)
+                    if _must_stub_result(tracker)
+                    else await _fetch_qa(slot_value, tracker)
+                )
 
-    def request_next_slot(
-        self,
-        dispatcher: CollectingDispatcher,
-        tracker: Tracker,
-        domain: Dict[Text, Any],
-    ) -> Optional[List[EventType]]:
-        return request_next_slot(self, dispatcher, tracker, domain)
+                slot_events += [SlotSet(STATUS_SLOT, result.status)]
 
-    async def validate_active_question(
-        self,
-        value: Text,
-        dispatcher: CollectingDispatcher,
-        tracker: Tracker,
-        domain: Dict[Text, Any],
-    ) -> Dict[Text, Any]:
-        result = (
-            _get_stub_qa_result(tracker)
-            if _must_stub_result(tracker)
-            else await _fetch_qa(value, tracker)
-        )
+                if (
+                    result.status == QuestionAnsweringStatus.SUCCESS and result.answers
+                ):  # not sure about this. Shouldn't happen
+                    dispatcher.utter_message(result.answers[0])
+                    slot_events += [SlotSet(ANSWERS_SLOT, result.answers)]
+                else:
+                    slot_events += [
+                        SlotSet(REQUESTED_SLOT, None),
+                        SlotSet(FEEDBACK_SLOT, SKIP_SLOT_PLACEHOLDER),
+                    ]
 
-        if result.status == QuestionAnsweringStatus.SUCCESS and result.answers:
-            dispatcher.utter_message(result.answers[0])
+            validation_events.extend(slot_events)
 
-        return {STATUS_SLOT: result.status, ANSWERS_SLOT: result.answers}
+        return validation_events
 
-    def validate_feedback(
-        self,
-        value: Text,
-        dispatcher: CollectingDispatcher,
-        tracker: Tracker,
-        domain: Dict[Text, Any],
-    ) -> Dict[Text, Any]:
-        if value is False:
-            dispatcher.utter_message(template="utter_post_feedback")
 
-        if not isinstance(value, bool):
-            return {FEEDBACK_SLOT: FEEDBACK_NOT_GIVEN}
+class ActionSubmitQuestionAnsweringForm(Action):
+    def name(self) -> Text:
+        return SUBMIT_ACTION_NAME
 
-        return {}
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
+    ) -> List[EventType]:
+        bind_logger(tracker)
 
-    def submit(
-        self,
-        dispatcher: CollectingDispatcher,
-        tracker: Tracker,
-        domain: Dict[Text, Any],
-    ) -> List[Dict]:
         feedback = tracker.get_slot(FEEDBACK_SLOT)
         full_question_result = {
             QUESTION_KEY: tracker.get_slot(QUESTION_SLOT),
@@ -252,10 +229,6 @@ def _get_stub_qa_result(tracker: Tracker):
 
 def _carry_user_utterance(tracker: Tracker) -> List[EventType]:
     return [
-        ActiveLoop(
-            None
-        ),  # Ending it manually to have events in correct order to fit stories
-        SlotSet(REQUESTED_SLOT, None),
         ActionExecuted("utter_ask_another_question"),
         BotUttered(metadata={"template_name": "utter_ask_another_question"}),
         ActionExecuted(ACTION_LISTEN_NAME),

--- a/core/data/rules.yml
+++ b/core/data/rules.yml
@@ -317,6 +317,7 @@ rules:
       - active_loop: null
       - slot_was_set:
           - question_answering_status: success
+      - action: action_submit_question_answering_form
       - action: utter_ask_another_question
 
   - rule: greet QA out_of_distribution
@@ -325,9 +326,11 @@ rules:
       - intent: greet
       - action: action_greeting_messages
       - intent: nlu_fallback
+      - action: action_activate_fallback_question_answering_form
       - action: question_answering_form
       - slot_was_set:
           - question_answering_status: out_of_distribution
+      - action: action_submit_question_answering_form
       - action: utter_ask_how_may_i_help_fallback
 
   - rule: QA out_of_distribution
@@ -338,6 +341,7 @@ rules:
       - active_loop: null
       - slot_was_set:
           - question_answering_status: out_of_distribution
+      - action: action_submit_question_answering_form
       - action: utter_cant_answer
       - action: utter_ask_different_question
 
@@ -347,9 +351,11 @@ rules:
       - intent: greet
       - action: action_greeting_messages
       - intent: nlu_fallback
+      - action: action_activate_fallback_question_answering_form
       - action: question_answering_form
       - slot_was_set:
           - question_answering_status: failure
+      - action: action_submit_question_answering_form
       - action: utter_ask_how_may_i_help_fallback
 
   - rule: assessment QA failure
@@ -362,6 +368,7 @@ rules:
       - active_loop: null
       - slot_was_set:
           - question_answering_status: failure
+      - action: action_submit_question_answering_form
       - action: utter_question_answering_error
       - action: utter_try_again_later
       - action: action_qa_goodbye
@@ -374,6 +381,7 @@ rules:
       - active_loop: null
       - slot_was_set:
           - question_answering_status: failure
+      - action: action_submit_question_answering_form
       - action: utter_question_answering_error
       - action: utter_ask_assess_after_error
 
@@ -387,6 +395,7 @@ rules:
       - active_loop: null
       - slot_was_set:
           - question_answering_status: need_assessment
+      - action: action_submit_question_answering_form
       - action: utter_need_assessment_already_done
       - action: utter_ask_another_question
 
@@ -398,6 +407,7 @@ rules:
       - active_loop: null
       - slot_was_set:
           - question_answering_status: need_assessment
+      - action: action_submit_question_answering_form
       - action: utter_need_assessment
       - action: utter_ask_assess_to_answer
 
@@ -775,6 +785,7 @@ rules:
     steps:
       - intent: nlu_fallback
       - action: action_check_task_allowed
+      - action: action_activate_fallback_question_answering_form
       - action: question_answering_form
       - active_loop: question_answering_form
     wait_for_user_input: false

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -81,6 +81,10 @@ actions:
   - validate_contact_risk_form
   - validate_test_navigation_form
   - action_clear_test_navigation_slots
+  - validate_question_answering_form
+  - action_activate_fallback_question_answering_form
+  - action_ask_active_question
+  - action_submit_question_answering_form
 
 forms:
   - home_assistance_form:
@@ -96,6 +100,16 @@ forms:
   - daily_ci_feel_worse_form:
   - daily_ci_keep_or_cancel_form:
   - question_answering_form:
+      active_question:
+        - type: from_text
+      feedback:
+        - type: from_intent
+          intent: affirm
+          value: true
+        - type: from_intent
+          intent: deny
+          value: false
+        - type: from_text
   - test_navigation_form:
       test_navigation__postal_code:
         - type: from_text

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -706,18 +706,7 @@ responses:
   utter_ask_feedback:
     - text: "Was this answer useful?"
 
-  utter_ask_feedback_error:
-    - text: "Sorry, please tell me whether this answer was useful or not"
-      buttons:
-        - title: Yes
-          payload: "/affirm"
-        - title: No
-          payload: "/deny"
-      custom:
-        data:
-          disableTextField: "true"
-
-  utter_post_feedback:
+  utter_feedback_false:
     - text: "Got it, sorry about that! I’m still learning so your feedback helps me improve and provide better answers"
 
   utter_question_answering_error:
@@ -1123,8 +1112,8 @@ responses:
   utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation:
     - text: OK, since you still have some symptoms, I recommend that you stay isolated and that you continue to rest
 
-  utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation:
-    - text: OK, since you still feel sick, I recommend that you stay isolated and that you continue to rest
+  ? utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation
+  : - text: OK, since you still feel sick, I recommend that you stay isolated and that you continue to rest
 
   utter_daily_checkin_validation_code:
     - text: "Hi {first_name}, this is the validation code for your daily check-in enrollment: {validation_code}. If you did not request to enroll in the daily check-in, please ignore this text message"

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -594,7 +594,8 @@ responses:
     - text: "Je peux répondre à vos questions sur une variété de sujets entourant la Covid-19"
 
   utter_qa_disclaimer:
-    - text: "Veuillez noter que pour le moment, je suis en mesure de répondre à un
+    - text:
+        "Veuillez noter que pour le moment, je suis en mesure de répondre à un
         nombre limité de questions, mais je m'améliore constamment et j'apprends
         à l'aide des questions que vous me posez"
 
@@ -611,7 +612,8 @@ responses:
   utter_qa_sample_contagion:
     - text: "Si nous avons Covid-19, combien de temp sommes-nous contagieux?"
     - text: "Combien de temps sommes-nous contagieux quand nous avons Covid-19?"
-    - text: "Après la disparition des symptômes, combien de temps une personne reste
+    - text:
+        "Après la disparition des symptômes, combien de temps une personne reste
         contagieuse?"
     - text: "Combien de temps une personne est-elle contagieuse?"
     - text: "Suis-je contagieux longtemps après que j'ai contracté le virus?"
@@ -621,9 +623,11 @@ responses:
     - text: "Combien de temp le virus vit-il sur des surfaces?"
     - text: "Pour combien de temps COVID19 peut rester en vie sur des surfaces
         différentes?"
-    - text: "Est-il vrai que Covid-19 peut survivre jusqu'à quelques jours sur les
+    - text:
+        "Est-il vrai que Covid-19 peut survivre jusqu'à quelques jours sur les
         surfaces dures?"
-    - text: "Combien de temps le virus survit-il sur une surface comme une poignée
+    - text:
+        "Combien de temps le virus survit-il sur une surface comme une poignée
         de porte?"
     - text: "Combien de temps est-ce que la Covid 19 peut rester sur des surfaces?"
 
@@ -703,7 +707,8 @@ responses:
     - text: "Combien de cas au Québec?"
     - text: "Combien de personnes sont infectées au Québec?"
     - text: "Combien de cas sont aux États-Unis?"
-    - text: "De la population infectée dans le monde entier quel sera le rapport des
+    - text:
+        "De la population infectée dans le monde entier quel sera le rapport des
         personnes asymptomatiques?"
 
   utter_ask_active_question:
@@ -712,18 +717,7 @@ responses:
   utter_ask_feedback:
     - text: "Est-ce que cette réponse était utile?"
 
-  utter_ask_feedback_error:
-    - text: "Désolée, veuillez me dire si cette réponse était utile ou non"
-      buttons:
-        - title: Oui
-          payload: "/affirm"
-        - title: Non
-          payload: "/deny"
-      custom:
-        data:
-          disableTextField: "true"
-
-  utter_post_feedback:
+  utter_feedback_false:
     - text: "Je suis désolée, c'est noté! J'apprends constamment, alors votre opinion me permettra de m'améliorer et de vous donner de meilleures réponses"
 
   utter_question_answering_error:
@@ -1129,8 +1123,8 @@ responses:
   utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation:
     - text: D'accord. Puisque vous avez encore certains symptômes, je vous conseille de continuer à vous isoler et à vous reposer
 
-  utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation:
-    - text: C'est noté. Puisque vous êtes encore malade, je vous conseille de continuer à vous isoler et à vous reposer
+  ? utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation
+  : - text: C'est noté. Puisque vous êtes encore malade, je vous conseille de continuer à vous isoler et à vous reposer
 
   utter_daily_checkin_validation_code:
     - text: "Bonjour {first_name}, voici le code de validation pour l’inscription au suivi quotidien : {validation_code}. Si vous n’avez pas demandé à vous inscrire au suivi quotidien, veuillez ignorer ce message"


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
Question answering form is now split in one ask action, one activation action, triggered only if the form is a fallback (It's a lot cleaner and clearer this way, even though not unit-testable), the regular validation action, and a submit action. The submit action would not be necessary if we could end the form inside it, but it might still be cleaner.

For the feedback carrying behaviour, I kept the current approach, as I didn't think of a cleaner way to do. If trying to use a kind of digression, each accepted intention would have to be in a different rule, and we would have to deactivate the form before entering the other flow, thus carrying the user input somehow, and repeat existing rules...

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
closes #33

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
