### PR TITLE
feat: new daily check-in assessments (#30)

### DIFF
--- a/action-server/covidflow/actions/action_default_fallback.py
+++ b/action-server/covidflow/actions/action_default_fallback.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from typing import Any, Dict, List, Text
 
 import structlog
@@ -20,6 +21,8 @@ from .lib.log_util import bind_logger
 logger = structlog.get_logger()
 
 ERROR_SUFFIX = "_error"
+
+VARIATION_REGEX = r"___.*$"
 
 ACTION_NAME = "action_default_fallback"  # We could call it otherwise when https://github.com/RasaHQ/rasa/issues/6516 will be solved
 
@@ -54,6 +57,7 @@ def _with_error_suffix(template_name: str) -> str:
     if template_name.endswith(ERROR_SUFFIX):
         return template_name
     else:
+        template_name = re.sub(VARIATION_REGEX, "", template_name)
         return f"{template_name}{ERROR_SUFFIX}"
 
 

--- a/action-server/covidflow/actions/daily_ci_assessment_common.py
+++ b/action-server/covidflow/actions/daily_ci_assessment_common.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import Dict, List
 
-from rasa_sdk import Tracker
-from rasa_sdk.events import SlotSet
+from rasa_sdk import Action, Tracker
+from rasa_sdk.events import EventType, SlotSet
+from rasa_sdk.executor import CollectingDispatcher
 from structlog import get_logger
 
 from covidflow.constants import (
@@ -12,31 +13,42 @@ from covidflow.constants import (
 )
 from covidflow.utils.persistence import cancel_reminder, save_assessment
 
+from .lib.log_util import bind_logger
+
 logger = get_logger(__name__)
 
 LAST_PREFIX = "last_"
 
+ACTION_NAME = "action_submit_daily_ci_assessment"
 
-def submit_daily_ci_assessment(tracker: Tracker) -> List[dict]:
-    events = [SlotSet(SELF_ASSESS_DONE_SLOT, True)]
 
-    ## Filling empty slots with previous day values
-    slots_to_add = {}
-    for last_slot in LAST_ASSESSMENT_SLOTS:
-        current_slot = last_slot.replace(LAST_PREFIX, "")
-        if tracker.get_slot(current_slot) is None:
-            value = tracker.get_slot(last_slot)
-            slots_to_add.update({current_slot: value})
+class ActionSubmitDailyCiAssessment(Action):
+    def name(self):
+        return ACTION_NAME
 
-    try:
-        save_assessment({**tracker.current_slot_values(), **slots_to_add})
-    except:
-        logger.warn("Failed to save assessment", exc_info=True)
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
+    ) -> List[EventType]:
+        bind_logger(tracker)
+        events = [SlotSet(SELF_ASSESS_DONE_SLOT, True)]
 
-    if tracker.get_slot(SYMPTOMS_SLOT) == Symptoms.SEVERE:
+        ## Filling empty slots with previous day values
+        slots_to_add = {}
+        for last_slot in LAST_ASSESSMENT_SLOTS:
+            current_slot = last_slot.replace(LAST_PREFIX, "")
+            if tracker.get_slot(current_slot) is None:
+                value = tracker.get_slot(last_slot)
+                slots_to_add.update({current_slot: value})
+
         try:
-            cancel_reminder(tracker.current_slot_values())
+            save_assessment({**tracker.current_slot_values(), **slots_to_add})
         except:
-            logger.warn("Failed to cancel reminder", exc_info=True)
+            logger.warn("Failed to save assessment", exc_info=True)
 
-    return events + [SlotSet(key, value) for key, value in slots_to_add.items()]
+        if tracker.get_slot(SYMPTOMS_SLOT) == Symptoms.SEVERE:
+            try:
+                cancel_reminder(tracker.current_slot_values())
+            except:
+                logger.warn("Failed to cancel reminder", exc_info=True)
+
+        return events + [SlotSet(key, value) for key, value in slots_to_add.items()]

--- a/action-server/covidflow/actions/daily_ci_feel_better_form.py
+++ b/action-server/covidflow/actions/daily_ci_feel_better_form.py
@@ -16,6 +16,7 @@ from covidflow.constants import (
     Symptoms,
 )
 
+from .lib.form_helper import end_form_additional_events
 from .lib.log_util import bind_logger
 
 FORM_NAME = "daily_ci_feel_better_form"
@@ -26,6 +27,14 @@ IS_SYMPTOM_FREE_SLOT = "daily_ci_feel_better_form_is_symptom_free"
 
 ASK_HAS_OTHER_MILD_SYMPTOMS_ACTION_NAME = f"action_ask_{HAS_OTHER_MILD_SYMPTOMS_SLOT}"
 ASK_HAS_COUGH_ACTION_NAME = f"action_ask_{FORM_NAME}_{HAS_COUGH_SLOT}"
+
+ORDERED_FORM_SLOTS = [
+    HAS_FEVER_SLOT,
+    HAS_COUGH_SLOT,
+    HAS_DIFF_BREATHING_SLOT,
+    HAS_OTHER_MILD_SYMPTOMS_SLOT,
+    IS_SYMPTOM_FREE_SLOT,
+]
 
 
 class ActionAskDailyCiFeelBetterFormHasCough(Action):
@@ -90,7 +99,7 @@ class ValidateDailyCiFeelBetterForm(Action):
                 slot_events += _validate_has_cough(slot_value, dispatcher)
                 if (
                     tracker.get_slot(LAST_SYMPTOMS_SLOT) != Symptoms.MODERATE
-                ):  # Next slot only happens when symptoms are moderate
+                ):  # Next slot is only asked when symptoms are moderate
                     slot_events.append(
                         SlotSet(HAS_DIFF_BREATHING_SLOT, SKIP_SLOT_PLACEHOLDER)
                     )
@@ -145,11 +154,9 @@ def _validate_has_diff_breathing(
         dispatcher.utter_message(
             template="utter_daily_ci_feel_better_breathing_difficulty_recommendation_2"
         )
-        return [
-            SlotSet(REQUESTED_SLOT, None),
-            SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, SKIP_SLOT_PLACEHOLDER),
-            SlotSet(IS_SYMPTOM_FREE_SLOT, SKIP_SLOT_PLACEHOLDER),
-        ]  # Récupérer le cossin de l'autre
+        return [SlotSet(REQUESTED_SLOT, None)] + end_form_additional_events(
+            HAS_DIFF_BREATHING_SLOT, ORDERED_FORM_SLOTS
+        )
     else:
         return [SlotSet(SYMPTOMS_SLOT, Symptoms.MILD)]
 
@@ -165,10 +172,9 @@ def _validate_has_other_mild_symptoms(
         dispatcher.utter_message(
             template="utter_daily_ci_feel_better_form_has_other_mild_symptoms_recommendation"
         )
-        return [
-            SlotSet(REQUESTED_SLOT, None),
-            SlotSet(IS_SYMPTOM_FREE_SLOT, SKIP_SLOT_PLACEHOLDER),
-        ]
+        return [SlotSet(REQUESTED_SLOT, None)] + end_form_additional_events(
+            HAS_OTHER_MILD_SYMPTOMS_SLOT, ORDERED_FORM_SLOTS
+        )
 
     return []
 

--- a/action-server/covidflow/actions/daily_ci_feel_no_change_form.py
+++ b/action-server/covidflow/actions/daily_ci_feel_no_change_form.py
@@ -87,8 +87,8 @@ class ValidateDailyCiFeelNoChangeForm(Action):
             elif slot_name == HAS_COUGH_SLOT:
                 slot_events += _validate_has_cough(slot_value, dispatcher)
                 if (
-                    tracker.get_slot(LAST_SYMPTOMS_SLOT) == Symptoms.MILD
-                ):  # Stop there if symptoms were mild
+                    tracker.get_slot(LAST_SYMPTOMS_SLOT) != Symptoms.MODERATE
+                ):  # Do not ask for diff breathing if symptoms were not moderate
                     slot_events.extend(
                         [
                             SlotSet(REQUESTED_SLOT, None),

--- a/action-server/covidflow/actions/lib/form_helper.py
+++ b/action-server/covidflow/actions/lib/form_helper.py
@@ -6,6 +6,8 @@ from rasa_sdk.events import EventType, SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import REQUESTED_SLOT, FormAction
 
+from covidflow.constants import SKIP_SLOT_PLACEHOLDER
+
 logger = structlog.get_logger()
 
 
@@ -111,3 +113,14 @@ def _form_slots_to_validate(tracker: Tracker) -> Dict[Text, Any]:
             break
 
     return slots_to_validate
+
+
+# Fills all the slots that were not yet asked. Workaround for https://github.com/RasaHQ/rasa/issues/6569
+def end_form_additional_events(
+    actual_slot: str, ordered_form_slots: List[str]
+) -> List[EventType]:
+    actual_slot_index = ordered_form_slots.index(actual_slot)
+    return [
+        SlotSet(slot, SKIP_SLOT_PLACEHOLDER)
+        for slot in ordered_form_slots[actual_slot_index + 1 :]
+    ]

--- a/action-server/tests/actions/test_daily_ci_assessment_common.py
+++ b/action-server/tests/actions/test_daily_ci_assessment_common.py
@@ -1,0 +1,121 @@
+import pytest
+from asynctest import patch
+from rasa_sdk.events import SlotSet
+
+from covidflow.actions.daily_ci_assessment_common import ActionSubmitDailyCiAssessment
+from covidflow.constants import (
+    HAS_COUGH_SLOT,
+    HAS_DIFF_BREATHING_SLOT,
+    HAS_FEVER_SLOT,
+    LAST_HAS_COUGH_SLOT,
+    LAST_HAS_DIFF_BREATHING_SLOT,
+    LAST_HAS_FEVER_SLOT,
+    LAST_SYMPTOMS_SLOT,
+    SELF_ASSESS_DONE_SLOT,
+    SYMPTOMS_SLOT,
+    Symptoms,
+)
+
+from .action_test_helper import INITIAL_SLOT_VALUES, ActionTestCase
+
+LAST_SYMPTOMS = {
+    LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
+    LAST_HAS_FEVER_SLOT: True,
+    LAST_HAS_COUGH_SLOT: False,
+    LAST_HAS_DIFF_BREATHING_SLOT: True,
+}
+
+NEW_SYMPTOMS = {
+    SYMPTOMS_SLOT: Symptoms.MILD,
+    HAS_FEVER_SLOT: True,
+    HAS_DIFF_BREATHING_SLOT: False,
+}
+
+
+class ActionSubmitDailyCiAssessmentTest(ActionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.action = ActionSubmitDailyCiAssessment()
+
+        self.patcher = patch(
+            "covidflow.actions.daily_ci_assessment_common.save_assessment"
+        )
+        self.mock_save_assessment = self.patcher.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_saves_with_last_values_if_new_ones_empty(self):
+        tracker = self.create_tracker(slots=LAST_SYMPTOMS)
+
+        await self.run_action(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, Symptoms.MODERATE),
+                SlotSet(HAS_FEVER_SLOT, True),
+                SlotSet(HAS_COUGH_SLOT, False),
+                SlotSet(HAS_DIFF_BREATHING_SLOT, True),
+            ]
+        )
+
+        self.assert_templates([])
+
+        self.mock_save_assessment.assert_called_once_with(
+            {
+                **INITIAL_SLOT_VALUES,
+                **LAST_SYMPTOMS,
+                SYMPTOMS_SLOT: Symptoms.MODERATE,
+                HAS_FEVER_SLOT: True,
+                HAS_COUGH_SLOT: False,
+                HAS_DIFF_BREATHING_SLOT: True,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_saves_with_new_values_overrides(self):
+        tracker = self.create_tracker(slots={**LAST_SYMPTOMS, **NEW_SYMPTOMS})
+
+        await self.run_action(tracker)
+
+        self.assert_events(
+            [SlotSet(SELF_ASSESS_DONE_SLOT, True), SlotSet(HAS_COUGH_SLOT, False)]
+        )
+
+        self.assert_templates([])
+
+        self.mock_save_assessment.assert_called_once_with(
+            {
+                **INITIAL_SLOT_VALUES,
+                **LAST_SYMPTOMS,
+                **NEW_SYMPTOMS,
+                HAS_COUGH_SLOT: False,
+            }
+        )
+
+    @pytest.mark.asyncio
+    @patch("covidflow.actions.daily_ci_assessment_common.cancel_reminder")
+    async def test_cancels_when_severe_symptoms(self, mock_cancel_reminder):
+        tracker = self.create_tracker(
+            slots={**LAST_SYMPTOMS, SYMPTOMS_SLOT: Symptoms.SEVERE}
+        )
+
+        await self.run_action(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(HAS_FEVER_SLOT, True),
+                SlotSet(HAS_COUGH_SLOT, False),
+                SlotSet(HAS_DIFF_BREATHING_SLOT, True),
+            ]
+        )
+
+        self.assert_templates([])
+
+        self.mock_save_assessment.assert_called_once()
+
+        mock_cancel_reminder.assert_called_once()

--- a/action-server/tests/actions/test_daily_ci_feel_better_form.py
+++ b/action-server/tests/actions/test_daily_ci_feel_better_form.py
@@ -1,786 +1,245 @@
-from unittest.mock import patch
-
-from rasa_sdk.events import ActiveLoop, SlotSet
+import pytest
+from rasa_sdk.events import SlotSet
 from rasa_sdk.forms import REQUESTED_SLOT
 
 from covidflow.actions.daily_ci_feel_better_form import (
     FORM_NAME,
     HAS_OTHER_MILD_SYMPTOMS_SLOT,
     IS_SYMPTOM_FREE_SLOT,
-    DailyCiFeelBetterForm,
+    ActionAskDailyCiFeelBetterFormHasCough,
+    ActionAskDailyCiFeelBetterFormHasOtherMildSymptoms,
+    ValidateDailyCiFeelBetterForm,
 )
 from covidflow.constants import (
-    FEEL_WORSE_SLOT,
     HAS_COUGH_SLOT,
     HAS_DIFF_BREATHING_SLOT,
     HAS_FEVER_SLOT,
-    LAST_HAS_DIFF_BREATHING_SLOT,
+    LAST_HAS_COUGH_SLOT,
     LAST_SYMPTOMS_SLOT,
-    SELF_ASSESS_DONE_SLOT,
+    SKIP_SLOT_PLACEHOLDER,
     SYMPTOMS_SLOT,
     Symptoms,
 )
 
-from .form_test_helper import FormTestCase
-
-DOMAIN = {
-    "responses": {
-        "utter_ask_daily_ci__feel_better__has_other_mild_symptoms_error": [
-            {"text": ""}
-        ],
-        "utter_ask_daily_ci__feel_better__is_symptom_free_error": [{"text": ""}],
-    }
-}
+from .action_test_helper import ActionTestCase
+from .validate_action_test_helper import ValidateActionTestCase
 
 
-class TestDailyCiFeelBetterForm(FormTestCase):
+class TestActionAskDailyCiFeelBetterFormHasCough(ActionTestCase):
     def setUp(self):
         super().setUp()
-        self.form = DailyCiFeelBetterForm()
+        self.action = ActionAskDailyCiFeelBetterFormHasCough()
 
-        self.patcher = patch(
-            "covidflow.actions.daily_ci_assessment_common.save_assessment"
-        )
-        self.mock_save_assessment = self.patcher.start()
+    @pytest.mark.asyncio
+    async def test_did_not_have_cough(self):
+        tracker = self.create_tracker(slots={LAST_HAS_COUGH_SLOT: False})
 
-    def tearDown(self):
-        super().tearDown()
-        self.patcher.stop()
+        await self.run_action(tracker)
 
-    def test_moderate(self):
-        self._test_form_activation(last_symptoms=Symptoms.MODERATE)
+        self.assert_events([])
 
-    def test_mild(self):
-        self._test_form_activation(last_symptoms=Symptoms.MILD)
+        self.assert_templates(["utter_ask_daily_ci_feel_better_form_has_cough"])
 
-    def _test_form_activation(self, last_symptoms: str):
-        tracker = self.create_tracker(
-            slots={LAST_SYMPTOMS_SLOT: last_symptoms}, active_loop=False
-        )
+    @pytest.mark.asyncio
+    async def test_already_had_cough(self):
+        tracker = self.create_tracker(slots={LAST_HAS_COUGH_SLOT: True})
 
-        self.run_form(tracker, DOMAIN)
+        await self.run_action(tracker)
 
-        self.assert_events(
-            [
-                ActiveLoop(FORM_NAME),
-                SlotSet(FEEL_WORSE_SLOT, False),
-                SlotSet(REQUESTED_SLOT, HAS_FEVER_SLOT),
-            ]
-        )
+        self.assert_events([])
 
-        self.assert_templates(
-            [
-                "utter_daily_ci__feel_better__acknowledge",
-                "utter_ask_daily_ci__feel_better__has_fever",
-            ]
-        )
+        self.assert_templates(["utter_ask_daily_ci_feel_better_form_has_cough___still"])
 
-    def test_moderate_last_symptoms__fever(self):
-        self._test_fever(last_symptoms=Symptoms.MODERATE)
 
-    def test_mild_last_symptoms__fever(self):
-        self._test_fever(last_symptoms=Symptoms.MILD)
+class TestActionAskDailyCiFeelBetterFormHasOtherMildSymptoms(ActionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.action = ActionAskDailyCiFeelBetterFormHasOtherMildSymptoms()
 
-    def _test_fever(self, last_symptoms: str):
-        tracker = self.create_tracker(
-            slots={LAST_SYMPTOMS_SLOT: last_symptoms, REQUESTED_SLOT: HAS_FEVER_SLOT},
-            intent="affirm",
-        )
+    @pytest.mark.asyncio
+    async def test_last_symptoms_moderate(self):
+        tracker = self.create_tracker(slots={LAST_SYMPTOMS_SLOT: Symptoms.MODERATE})
 
-        self.run_form(tracker, DOMAIN)
+        await self.run_action(tracker)
 
-        self.assert_events(
-            [SlotSet(HAS_FEVER_SLOT, True), SlotSet(REQUESTED_SLOT, HAS_COUGH_SLOT)]
-        )
+        self.assert_events([])
 
         self.assert_templates(
             [
-                "utter_daily_ci__acknowledge_fever",
-                "utter_daily_ci__take_acetaminophen",
-                "utter_daily_ci__avoid_ibuprofen",
-                "utter_ask_daily_ci__feel_better__has_cough",
+                "utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms___with_acknowledge"
             ]
         )
 
-    def test_moderate_last_symptoms__no_fever(self):
-        self._test_no_fever(last_symptoms=Symptoms.MODERATE)
+    @pytest.mark.asyncio
+    async def test_last_symptoms_mild(self):
+        tracker = self.create_tracker(slots={LAST_SYMPTOMS_SLOT: Symptoms.MILD})
 
-    def test_mild_last_symptoms__no_fever(self):
-        self._test_no_fever(last_symptoms=Symptoms.MILD)
+        await self.run_action(tracker)
 
-    def _test_no_fever(self, last_symptoms: str):
-        tracker = self.create_tracker(
-            slots={LAST_SYMPTOMS_SLOT: last_symptoms, REQUESTED_SLOT: HAS_FEVER_SLOT},
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [SlotSet(HAS_FEVER_SLOT, False), SlotSet(REQUESTED_SLOT, HAS_COUGH_SLOT)]
-        )
+        self.assert_events([])
 
         self.assert_templates(
-            [
-                "utter_daily_ci__feel_better__acknowledge_no_fever",
-                "utter_ask_daily_ci__feel_better__has_cough",
-            ]
+            ["utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms"]
         )
 
-    def test_fever_error(self):
-        tracker = self.create_tracker(
-            slots={LAST_SYMPTOMS_SLOT: Symptoms.MILD, REQUESTED_SLOT: HAS_FEVER_SLOT},
-            text="anything",
+
+class TestValidateDailyCiFeelBetterForm(ValidateActionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.action = ValidateDailyCiFeelBetterForm()
+        self.form_name = FORM_NAME
+
+    @pytest.mark.asyncio
+    async def test_activation(self):
+        await self.check_activation()
+
+    @pytest.mark.asyncio
+    async def test_fever(self):
+        templates = [
+            "utter_daily_ci__acknowledge_fever",
+            "utter_daily_ci__take_acetaminophen",
+            "utter_daily_ci__avoid_ibuprofen",
+        ]
+
+        await self.check_slot_value_accepted(HAS_FEVER_SLOT, True, templates=templates)
+
+    @pytest.mark.asyncio
+    async def test_no_fever(self):
+        templates = ["utter_daily_ci_feel_better_acknowledge_no_fever"]
+
+        await self.check_slot_value_accepted(HAS_FEVER_SLOT, False, templates=templates)
+
+    @pytest.mark.asyncio
+    async def test_mild_last_symptoms_cough(self):
+        previous_slots = {LAST_SYMPTOMS_SLOT: Symptoms.MILD}
+        templates = [
+            "utter_daily_ci__cough_syrup_may_help",
+            "utter_daily_ci__cough_syrup_pharmacist",
+        ]
+        extra_events = [SlotSet(HAS_DIFF_BREATHING_SLOT, SKIP_SLOT_PLACEHOLDER)]
+
+        await self.check_slot_value_accepted(
+            HAS_COUGH_SLOT,
+            True,
+            previous_slots=previous_slots,
+            extra_events=extra_events,
+            templates=templates,
         )
 
-        self.run_form(tracker, DOMAIN)
+    @pytest.mark.asyncio
+    async def test_mild_last_symptoms_no_cough(self):
+        previous_slots = {LAST_SYMPTOMS_SLOT: Symptoms.MILD}
+        templates = ["utter_daily_ci__acknowledge_no_cough"]
+        extra_events = [SlotSet(HAS_DIFF_BREATHING_SLOT, SKIP_SLOT_PLACEHOLDER)]
 
-        self.assert_events(
-            [SlotSet(HAS_FEVER_SLOT, None), SlotSet(REQUESTED_SLOT, HAS_FEVER_SLOT)]
+        await self.check_slot_value_accepted(
+            HAS_COUGH_SLOT,
+            False,
+            previous_slots=previous_slots,
+            extra_events=extra_events,
+            templates=templates,
         )
 
-        self.assert_templates(
-            ["utter_ask_daily_ci__feel_better__has_fever_error",]
+    @pytest.mark.asyncio
+    async def test_moderate_last_symptoms_cough(self):
+        previous_slots = {LAST_SYMPTOMS_SLOT: Symptoms.MODERATE}
+        templates = [
+            "utter_daily_ci__cough_syrup_may_help",
+            "utter_daily_ci__cough_syrup_pharmacist",
+        ]
+
+        await self.check_slot_value_accepted(
+            HAS_COUGH_SLOT, True, previous_slots=previous_slots, templates=templates
         )
 
-    def test_moderate_last_symptoms__fever_cough(self):
-        self._test_moderate_last_symptoms__cough(fever=True)
+    @pytest.mark.asyncio
+    async def test_moderate_last_symptoms_no_cough(self):
+        previous_slots = {LAST_SYMPTOMS_SLOT: Symptoms.MODERATE}
+        templates = ["utter_daily_ci__acknowledge_no_cough"]
 
-    def test_moderate_last_symptoms__no_fever_cough(self):
-        self._test_moderate_last_symptoms__cough(fever=False)
-
-    def _test_moderate_last_symptoms__cough(self, fever: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_COUGH_SLOT,
-                HAS_FEVER_SLOT: fever,
-            },
-            intent="affirm",
+        await self.check_slot_value_accepted(
+            HAS_COUGH_SLOT, False, previous_slots=previous_slots, templates=templates
         )
 
-        self.run_form(tracker, DOMAIN)
+    @pytest.mark.asyncio
+    async def test_has_diff_breathing(self):
+        templates = [
+            "utter_daily_ci_feel_better_breathing_difficulty_recommendation_1",
+            "utter_daily_ci_feel_better_breathing_difficulty_recommendation_2",
+        ]
+        extra_events = [
+            SlotSet(REQUESTED_SLOT, None),
+            SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, SKIP_SLOT_PLACEHOLDER),
+            SlotSet(IS_SYMPTOM_FREE_SLOT, SKIP_SLOT_PLACEHOLDER),
+        ]
 
-        self.assert_events(
-            [
-                SlotSet(HAS_COUGH_SLOT, True),
-                SlotSet(REQUESTED_SLOT, HAS_DIFF_BREATHING_SLOT),
-            ]
+        await self.check_slot_value_accepted(
+            HAS_DIFF_BREATHING_SLOT,
+            True,
+            extra_events=extra_events,
+            templates=templates,
         )
 
-        self.assert_templates(
-            [
-                "utter_daily_ci__cough_syrup_may_help",
-                "utter_daily_ci__cough_syrup_pharmacist",
-                "utter_ask_daily_ci__feel_better__has_diff_breathing",
-            ]
+    @pytest.mark.asyncio
+    async def test_has_no_diff_breathing(self):
+        extra_events = [SlotSet(SYMPTOMS_SLOT, Symptoms.MILD)]
+
+        await self.check_slot_value_accepted(
+            HAS_DIFF_BREATHING_SLOT, False, extra_events=extra_events
         )
 
-    def test_moderate_last_symptoms__fever_no_cough(self):
-        self._test_moderate_last_symptoms__no_cough(fever=True)
+    @pytest.mark.asyncio
+    async def test_has_other_mild_symptoms(self):
+        await self._test_has_some_mild_symptom(False, False, True)
 
-    def test_moderate_last_symptoms__no_fever_no_cough(self):
-        self._test_moderate_last_symptoms__no_cough(fever=False)
+    @pytest.mark.asyncio
+    async def test_has_no_other_mild_symptoms_has_fever(self):
+        await self._test_has_some_mild_symptom(True, False, False)
 
-    def _test_moderate_last_symptoms__no_cough(self, fever: bool):
-        tracker = self.create_tracker(
-            slots={
-                REQUESTED_SLOT: HAS_COUGH_SLOT,
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                HAS_FEVER_SLOT: fever,
-            },
-            intent="deny",
+    @pytest.mark.asyncio
+    async def test_has_no_other_mild_symptoms_has_cough(self):
+        await self._test_has_some_mild_symptom(False, True, False)
+
+    async def _test_has_some_mild_symptom(
+        self, fever: bool, cough: bool, other_mild: bool
+    ):
+        previous_slots = {HAS_FEVER_SLOT: fever, HAS_COUGH_SLOT: cough}
+        templates = [
+            "utter_daily_ci_feel_better_form_has_other_mild_symptoms_recommendation"
+        ]
+        extra_events = [
+            SlotSet(REQUESTED_SLOT, None),
+            SlotSet(IS_SYMPTOM_FREE_SLOT, SKIP_SLOT_PLACEHOLDER),
+        ]
+
+        await self.check_slot_value_accepted(
+            HAS_OTHER_MILD_SYMPTOMS_SLOT,
+            other_mild,
+            previous_slots=previous_slots,
+            extra_events=extra_events,
+            templates=templates,
         )
 
-        self.run_form(tracker, DOMAIN)
+    @pytest.mark.asyncio
+    async def test_has_no_listed_mild_symptoms(self):
+        previous_slots = {HAS_FEVER_SLOT: False, HAS_COUGH_SLOT: False}
 
-        self.assert_events(
-            [
-                SlotSet(HAS_COUGH_SLOT, False),
-                SlotSet(REQUESTED_SLOT, HAS_DIFF_BREATHING_SLOT),
-            ]
+        await self.check_slot_value_accepted(
+            HAS_OTHER_MILD_SYMPTOMS_SLOT, False, previous_slots=previous_slots
         )
 
-        self.assert_templates(
-            [
-                "utter_daily_ci__acknowledge_no_cough",
-                "utter_ask_daily_ci__feel_better__has_diff_breathing",
-            ]
+    @pytest.mark.asyncio
+    async def test_is_symptom_free(self):
+        extra_events = [SlotSet(SYMPTOMS_SLOT, Symptoms.NONE)]
+        await self.check_slot_value_accepted(
+            IS_SYMPTOM_FREE_SLOT, True, extra_events=extra_events
         )
 
-    def test_cough_error(self):
-        tracker = self.create_tracker(
-            slots={
-                REQUESTED_SLOT: HAS_COUGH_SLOT,
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                HAS_FEVER_SLOT: True,
-            },
-            text="anything",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [SlotSet(HAS_COUGH_SLOT, None), SlotSet(REQUESTED_SLOT, HAS_COUGH_SLOT),]
-        )
-
-        self.assert_templates(
-            ["utter_ask_daily_ci__feel_better__has_cough_error",]
-        )
-
-    def test_moderate_last_symptoms__fever_cough__diff_breathing(self):
-        self._test_moderate_last_symptoms__diff_breathing(fever=True, cough=True)
-
-    def test_moderate_last_symptoms__no_fever_cough__diff_breathing(self):
-        self._test_moderate_last_symptoms__diff_breathing(fever=False, cough=True)
-
-    def test_moderate_last_symptoms__fever_no_cough__diff_breathing(self):
-        self._test_moderate_last_symptoms__diff_breathing(fever=True, cough=False)
-
-    def test_moderate_last_symptoms__no_fever_no_cough__diff_breathing(self):
-        self._test_moderate_last_symptoms__diff_breathing(fever=False, cough=False)
-
-    def _test_moderate_last_symptoms__diff_breathing(self, fever: bool, cough: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_DIFF_BREATHING_SLOT,
-                HAS_FEVER_SLOT: fever,
-                HAS_COUGH_SLOT: cough,
-            },
-            intent="affirm",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_DIFF_BREATHING_SLOT, True),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                SlotSet(SYMPTOMS_SLOT, Symptoms.MODERATE),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates(
-            [
-                "utter_daily_ci__feel_better__breathing_difficulty_recommendation_1",
-                "utter_daily_ci__feel_better__breathing_difficulty_recommendation_2",
-            ]
-        )
-
-    def test_moderate_last_symptoms__fever_cough__no_diff_breathing(self):
-        self._test_moderate_last_symptoms__no_diff_breathing(fever=True, cough=True)
-
-    def test_moderate_last_symptoms__no_fever_cough__no_diff_breathing(self):
-        self._test_moderate_last_symptoms__no_diff_breathing(fever=False, cough=True)
-
-    def test_moderate_last_symptoms__fever_no_cough__no_diff_breathing(self):
-        self._test_moderate_last_symptoms__no_diff_breathing(fever=True, cough=False)
-
-    def test_moderate_last_symptoms__no_fever_no_cough__no_diff_breathing(self):
-        self._test_moderate_last_symptoms__no_diff_breathing(fever=False, cough=False)
-
-    def _test_moderate_last_symptoms__no_diff_breathing(self, fever: bool, cough: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_DIFF_BREATHING_SLOT,
-                HAS_FEVER_SLOT: fever,
-                HAS_COUGH_SLOT: cough,
-            },
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
-                SlotSet(SYMPTOMS_SLOT, Symptoms.MILD),
-                SlotSet(REQUESTED_SLOT, HAS_OTHER_MILD_SYMPTOMS_SLOT),
-            ]
-        )
-
-        self.assert_templates(
-            [
-                "utter_ask_daily_ci__feel_better__has_other_mild_symptoms_with_acknowledge"
-            ]
-        )
-
-    def test_diff_breathing_error(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_DIFF_BREATHING_SLOT,
-                HAS_FEVER_SLOT: True,
-                HAS_COUGH_SLOT: True,
-            },
-            text="anything",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_DIFF_BREATHING_SLOT, None),
-                SlotSet(REQUESTED_SLOT, HAS_DIFF_BREATHING_SLOT),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_ask_daily_ci__feel_better__has_diff_breathing_error"]
-        )
-
-    def test_moderate_last_symptoms__fever_cough__other_mild(self):
-        self._test_moderate_last_symptoms__mild(fever=True, cough=True)
-
-    def test_moderate_last_symptoms__no_fever_cough__other_mild(self):
-        self._test_moderate_last_symptoms__mild(fever=False, cough=True)
-
-    def test_moderate_last_symptoms__fever_no_cough__other_mild(self):
-        self._test_moderate_last_symptoms__mild(fever=True, cough=False)
-
-    def test_moderate_last_symptoms__no_fever_no_cough__other_mild(self):
-        self._test_moderate_last_symptoms__mild(fever=False, cough=False)
-
-    def _test_moderate_last_symptoms__mild(self, fever: bool, cough: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
-                HAS_FEVER_SLOT: fever,
-                HAS_COUGH_SLOT: cough,
-                HAS_DIFF_BREATHING_SLOT: False,
-                SYMPTOMS_SLOT: Symptoms.MILD,
-            },
-            intent="affirm",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, True),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation"]
-        )
-
-    def test_moderate_last_symptoms__fever_cough__no_other_mild(self):
-        self._test_moderate_last_symptoms__no_other_mild(fever=True, cough=True)
-
-    def test_moderate_last_symptoms__no_fever_cough__no_other_mild(self):
-        self._test_moderate_last_symptoms__no_other_mild(fever=False, cough=True)
-
-    def test_moderate_last_symptoms__fever_no_cough__no_other_mild(self):
-        self._test_moderate_last_symptoms__no_other_mild(fever=True, cough=False)
-
-    def _test_moderate_last_symptoms__no_other_mild(self, fever: bool, cough: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
-                HAS_FEVER_SLOT: fever,
-                HAS_COUGH_SLOT: cough,
-                HAS_DIFF_BREATHING_SLOT: False,
-                SYMPTOMS_SLOT: Symptoms.MILD,
-            },
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, False),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation"]
-        )
-
-    def test_moderate_last_symptoms__no_fever_no_cough__no_other_mild(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_DIFF_BREATHING_SLOT: False,
-                SYMPTOMS_SLOT: Symptoms.MILD,
-            },
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, False),
-                SlotSet(REQUESTED_SLOT, IS_SYMPTOM_FREE_SLOT),
-            ]
-        )
-
-        self.assert_templates(["utter_ask_daily_ci__feel_better__is_symptom_free"])
-
-    def test_other_mild_symptoms_error(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_DIFF_BREATHING_SLOT: False,
-                SYMPTOMS_SLOT: Symptoms.MILD,
-            },
-            text="anything",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, None),
-                SlotSet(REQUESTED_SLOT, HAS_OTHER_MILD_SYMPTOMS_SLOT),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_ask_daily_ci__feel_better__has_other_mild_symptoms_error"]
-        )
-
-    def test_moderate_last_symptoms__is_symptom_free_afffirm(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_DIFF_BREATHING_SLOT: False,
-                HAS_OTHER_MILD_SYMPTOMS_SLOT: False,
-                SYMPTOMS_SLOT: Symptoms.MILD,
-            },
-            intent="affirm",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(IS_SYMPTOM_FREE_SLOT, True),
-                SlotSet(SYMPTOMS_SLOT, Symptoms.NONE),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates([])
-
-    def test_moderate_last_symptoms__is_symptoms_free_deny(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_DIFF_BREATHING_SLOT: False,
-                HAS_OTHER_MILD_SYMPTOMS_SLOT: False,
-                SYMPTOMS_SLOT: Symptoms.MILD,
-            },
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(IS_SYMPTOM_FREE_SLOT, False),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates(
-            [
-                "utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation"
-            ]
-        )
-
-    def test_moderate_last_symptoms__is_symptom_free_error(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MODERATE,
-                LAST_HAS_DIFF_BREATHING_SLOT: False,
-                REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_DIFF_BREATHING_SLOT: False,
-                HAS_OTHER_MILD_SYMPTOMS_SLOT: False,
-                SYMPTOMS_SLOT: Symptoms.MILD,
-            },
-            intent="something_else",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(IS_SYMPTOM_FREE_SLOT, None),
-                SlotSet(REQUESTED_SLOT, IS_SYMPTOM_FREE_SLOT),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_ask_daily_ci__feel_better__is_symptom_free_error"]
-        )
-
-    def test_mild_last_symptoms__fever_cough(self):
-        self._test_other_mild_last_symptoms__cough(fever=True)
-
-    def test_mild_last_symptoms__no_fever_cough(self):
-        self._test_other_mild_last_symptoms__cough(fever=False)
-
-    def _test_other_mild_last_symptoms__cough(self, fever: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MILD,
-                REQUESTED_SLOT: HAS_COUGH_SLOT,
-                HAS_FEVER_SLOT: fever,
-            },
-            intent="affirm",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_COUGH_SLOT, True),
-                SlotSet(REQUESTED_SLOT, HAS_OTHER_MILD_SYMPTOMS_SLOT),
-            ]
-        )
-
-        self.assert_templates(
-            [
-                "utter_daily_ci__cough_syrup_may_help",
-                "utter_daily_ci__cough_syrup_pharmacist",
-                "utter_ask_daily_ci__feel_better__has_other_mild_symptoms",
-            ]
-        )
-
-    def test_mild_last_symptoms__fever_no_cough(self):
-        self._test_other_mild_last_symptoms__no_cough(fever=True)
-
-    def test_mild_last_symptoms__no_fever_no_cough(self):
-        self._test_other_mild_last_symptoms__no_cough(fever=False)
-
-    def _test_other_mild_last_symptoms__no_cough(self, fever: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MILD,
-                REQUESTED_SLOT: HAS_COUGH_SLOT,
-                HAS_FEVER_SLOT: fever,
-            },
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_COUGH_SLOT, False),
-                SlotSet(REQUESTED_SLOT, HAS_OTHER_MILD_SYMPTOMS_SLOT),
-            ]
-        )
-
-        self.assert_templates(
-            [
-                "utter_daily_ci__acknowledge_no_cough",
-                "utter_ask_daily_ci__feel_better__has_other_mild_symptoms",
-            ]
-        )
-
-    def test_mild_last_symptoms__fever_cough__other_mild(self):
-        self._test_mild_last_symptoms__other_mild(fever=True, cough=True)
-
-    def test_mild_last_symptoms__no_fever_cough__other_mild(self):
-        self._test_mild_last_symptoms__other_mild(fever=False, cough=True)
-
-    def test_mild_last_symptoms__fever_no_cough__other_mild(self):
-        self._test_mild_last_symptoms__other_mild(fever=True, cough=False)
-
-    def test_mild_last_symptoms__no_fever_no_cough__other_mild(self):
-        self._test_mild_last_symptoms__other_mild(fever=False, cough=False)
-
-    def _test_mild_last_symptoms__other_mild(self, fever: bool, cough: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MILD,
-                LAST_HAS_DIFF_BREATHING_SLOT: False,
-                REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
-                HAS_FEVER_SLOT: fever,
-                HAS_COUGH_SLOT: cough,
-            },
-            intent="affirm",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, True),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                SlotSet(SYMPTOMS_SLOT, Symptoms.MILD),
-                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation"]
-        )
-
-        self.mock_save_assessment.assert_called()
-
-    def test_mild_last_symptoms__fever_cough__no_other_mild(self):
-        self._test_mild_last_symptoms__no_other_mild(fever=True, cough=True)
-
-    def test_mild_last_symptoms__no_fever_cough__no_other_mild(self):
-        self._test_mild_last_symptoms__no_other_mild(fever=False, cough=True)
-
-    def test_mild_last_symptoms__fever_no_cough__no_other_mild(self):
-        self._test_mild_last_symptoms__no_other_mild(fever=True, cough=False)
-
-    def _test_mild_last_symptoms__no_other_mild(self, fever: bool, cough: bool):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MILD,
-                LAST_HAS_DIFF_BREATHING_SLOT: False,
-                REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
-                HAS_FEVER_SLOT: fever,
-                HAS_COUGH_SLOT: cough,
-            },
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, False),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                SlotSet(SYMPTOMS_SLOT, Symptoms.MILD),
-                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation"]
-        )
-
-        self.mock_save_assessment.assert_called()
-
-    def test_mild_last_symptoms__is_symptom_free_affirm(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MILD,
-                LAST_HAS_DIFF_BREATHING_SLOT: False,
-                REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_OTHER_MILD_SYMPTOMS_SLOT: False,
-            },
-            intent="affirm",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(IS_SYMPTOM_FREE_SLOT, True),
-                SlotSet(SYMPTOMS_SLOT, Symptoms.NONE),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates([])
-
-        self.mock_save_assessment.assert_called()
-
-    def test_mild_last_symptoms__is_symptom_free_deny(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MILD,
-                LAST_HAS_DIFF_BREATHING_SLOT: False,
-                REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_OTHER_MILD_SYMPTOMS_SLOT: False,
-            },
-            intent="deny",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(IS_SYMPTOM_FREE_SLOT, False),
-                SlotSet(SELF_ASSESS_DONE_SLOT, True),
-                SlotSet(SYMPTOMS_SLOT, Symptoms.MILD),
-                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
-                ActiveLoop(None),
-                SlotSet(REQUESTED_SLOT, None),
-            ]
-        )
-
-        self.assert_templates(
-            [
-                "utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation"
-            ]
-        )
-
-        self.mock_save_assessment.assert_called()
-
-    def test_mild_last_symptoms__is_symptom_free_error(self):
-        tracker = self.create_tracker(
-            slots={
-                LAST_SYMPTOMS_SLOT: Symptoms.MILD,
-                LAST_HAS_DIFF_BREATHING_SLOT: False,
-                REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
-                HAS_FEVER_SLOT: False,
-                HAS_COUGH_SLOT: False,
-                HAS_OTHER_MILD_SYMPTOMS_SLOT: False,
-            },
-            intent="something_else",
-        )
-
-        self.run_form(tracker, DOMAIN)
-
-        self.assert_events(
-            [
-                SlotSet(IS_SYMPTOM_FREE_SLOT, None),
-                SlotSet(REQUESTED_SLOT, IS_SYMPTOM_FREE_SLOT),
-            ]
-        )
-
-        self.assert_templates(
-            ["utter_ask_daily_ci__feel_better__is_symptom_free_error"]
+    @pytest.mark.asyncio
+    async def test_is_not_symptom_free(self):
+        templates = [
+            "utter_daily_ci_feel_better_form_has_other_mild_symptoms_still_sick_recommendation"
+        ]
+        await self.check_slot_value_accepted(
+            IS_SYMPTOM_FREE_SLOT, False, templates=templates
         )

--- a/core/Makefile
+++ b/core/Makefile
@@ -80,7 +80,7 @@ train-fr:
 		--augmentation 0
 
 test-integration-en:
-	CORE_ENDPOINT_URL=http://localhost:5005 INTEGRATION_TESTS_REMINDER_ID_PROFILE_1=v9ZaeZyE INTEGRATION_TESTS_REMINDER_ID_PROFILE_2=JvmKA31V poetry run python -m rasa_integration_testing ../integration-tests-en daily_ci/*.yml
+	CORE_ENDPOINT_URL=http://localhost:5005 INTEGRATION_TESTS_REMINDER_ID_PROFILE_1=v9ZaeZyE INTEGRATION_TESTS_REMINDER_ID_PROFILE_2=JvmKA31V poetry run python -m rasa_integration_testing ../integration-tests-en
 
 test-integration-fr:
 	CORE_ENDPOINT_URL=http://localhost:5006 INTEGRATION_TESTS_REMINDER_ID_PROFILE_1=v9ZaeZyE INTEGRATION_TESTS_REMINDER_ID_PROFILE_2=JvmKA31V poetry run python -m rasa_integration_testing ../integration-tests-fr

--- a/core/Makefile
+++ b/core/Makefile
@@ -80,7 +80,7 @@ train-fr:
 		--augmentation 0
 
 test-integration-en:
-	CORE_ENDPOINT_URL=http://localhost:5005 INTEGRATION_TESTS_REMINDER_ID_PROFILE_1=v9ZaeZyE INTEGRATION_TESTS_REMINDER_ID_PROFILE_2=JvmKA31V poetry run python -m rasa_integration_testing ../integration-tests-en
+	CORE_ENDPOINT_URL=http://localhost:5005 INTEGRATION_TESTS_REMINDER_ID_PROFILE_1=v9ZaeZyE INTEGRATION_TESTS_REMINDER_ID_PROFILE_2=JvmKA31V poetry run python -m rasa_integration_testing ../integration-tests-en daily_ci/*.yml
 
 test-integration-fr:
 	CORE_ENDPOINT_URL=http://localhost:5006 INTEGRATION_TESTS_REMINDER_ID_PROFILE_1=v9ZaeZyE INTEGRATION_TESTS_REMINDER_ID_PROFILE_2=JvmKA31V poetry run python -m rasa_integration_testing ../integration-tests-fr

--- a/core/data/rules.yml
+++ b/core/data/rules.yml
@@ -657,6 +657,7 @@ rules:
     steps:
       - action: utter_ask_daily_ci__feel
       - intent: worse
+      - action: action_set_feel_worse_true
       - action: daily_ci_feel_worse_form
       - active_loop: daily_ci_feel_worse_form
     wait_for_user_input: false
@@ -673,6 +674,7 @@ rules:
     steps:
       - action: utter_ask_daily_ci__feel
       - intent: better
+      - action: utter_daily_ci_feel_better_acknowledge # Added. Need to do something with the feel worse slot too
       - action: daily_ci_feel_better_form
       - active_loop: daily_ci_feel_better_form
     wait_for_user_input: false
@@ -686,6 +688,7 @@ rules:
       - active_loop: null
       - slot_was_set:
           - symptoms: severe
+      - action: action_submit_daily_ci_assessment
       - action: action_severe_symptoms_recommendations
 
   - rule: Daily check-in worse to keep_or_cancel
@@ -694,6 +697,7 @@ rules:
     steps:
       - action: daily_ci_feel_worse_form
       - active_loop: null
+      - action: action_submit_daily_ci_assessment
       - action: daily_ci_keep_or_cancel_form
       - active_loop: daily_ci_keep_or_cancel_form
     wait_for_user_input: false
@@ -704,6 +708,7 @@ rules:
     steps:
       - action: daily_ci_feel_no_change_form
       - active_loop: null
+      - action: action_submit_daily_ci_assessment
       - action: daily_ci_keep_or_cancel_form
       - active_loop: daily_ci_keep_or_cancel_form
     wait_for_user_input: false
@@ -714,6 +719,7 @@ rules:
     steps:
       - action: daily_ci_feel_better_form
       - active_loop: null
+      - action: action_submit_daily_ci_assessment
       - action: daily_ci_keep_or_cancel_form
       - active_loop: daily_ci_keep_or_cancel_form
     wait_for_user_input: false

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -91,6 +91,17 @@ actions:
   - action_ask_preconditions
   - action_daily_ci_enroll_form_ended
 
+  - action_submit_daily_ci_assessment
+  - validate_daily_ci_feel_better_form
+  - action_ask_daily_ci_feel_better_form_has_other_mild_symptoms
+  - action_ask_daily_ci_feel_better_form_has_cough
+  - validate_daily_ci_feel_worse_form
+  - action_ask_daily_ci_feel_worse_form_has_cough
+  - action_ask_daily_ci_feel_worse_form_has_diff_breathing
+  - action_set_feel_worse_true
+  - validate_daily_ci_feel_no_change_form
+  - action_ask_daily_ci_feel_no_change_form_has_cough
+  - action_ask_daily_ci_feel_no_change_form_has_fever
 
 forms:
   - home_assistance_form:
@@ -136,8 +147,21 @@ forms:
           value: dont_know # Will reject first time and set to true second time
       has_dialogue: *boolean
   - daily_ci_feel_no_change_form:
+      has_fever: *boolean
+      has_cough: *boolean
+      has_diff_breathing: *boolean
   - daily_ci_feel_better_form:
+      has_fever: *boolean
+      has_cough: *boolean
+      has_diff_breathing: *boolean
+      daily_ci_feel_better_form_has_other_mild_symptoms: *boolean
+      daily_ci_feel_better_form_is_symptom_free: *boolean
   - daily_ci_feel_worse_form:
+      severe_symptoms: *boolean
+      has_fever: *boolean
+      has_diff_breathing: *boolean
+      daily_ci_feel_worse_form_has_diff_breathing_worsened: *boolean
+      has_cough: *boolean
   - daily_ci_keep_or_cancel_form:
   - question_answering_form:
       active_question:
@@ -330,13 +354,13 @@ slots:
   daily_ci_enroll__display_preconditions_examples:
     type: unfeaturized
 
-  daily_ci__feel_worse__has_diff_breathing_worsened:
+  daily_ci_feel_worse_form_has_diff_breathing_worsened:
     type: unfeaturized
 
-  daily_ci__feel_better__has_other_mild_symptoms:
+  daily_ci_feel_better_form_has_other_mild_symptoms:
     type: unfeaturized
 
-  daily_ci__feel_better__is_symptom_free:
+  daily_ci_feel_better_form_is_symptom_free:
     type: unfeaturized
 
   test_navigation__postal_code:

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -866,10 +866,10 @@ responses:
 
   ## Daily check-in - feel worse
 
-  utter_ask_daily_ci__feel_worse__severe_symptoms:
+  utter_ask_daily_ci_feel_worse_form_severe_symptoms:
     - text: "Are you experiencing any, or a combination of, the following symptoms: severe difficulty breathing, severe chest pain, having a hard time waking up, feeling confused or losing consciousness?"
 
-  utter_ask_daily_ci__feel_worse__severe_symptoms_error:
+  utter_ask_daily_ci_feel_worse_form_severe_symptoms_error:
     - text: "Sorry, are you experiencing any of the following symptoms:\n- Severe difficulty breathing\n- Severe chest pain\n- Having a hard time waking up\n- Feeling confused\n- Losing consciousness"
       buttons:
         - title: Yes
@@ -880,13 +880,13 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__acknowledge_no_severe_symptoms:
+  utter_daily_ci_feel_worse_acknowledge_no_severe_symptoms:
     - text: OK, now, let's check your symptoms
 
-  utter_ask_daily_ci__feel_worse__has_fever:
+  utter_ask_daily_ci_feel_worse_form_has_fever:
     - text: Is your temperature higher than 38°C or 100.4°F? (You can take your temperature now if you're not sure)
 
-  utter_ask_daily_ci__feel_worse__has_fever_error:
+  utter_ask_daily_ci_feel_worse_form_has_fever_error:
     - text: Sorry, is your temperature higher than 38C or 100.4F?
       buttons:
         - title: Yes
@@ -897,13 +897,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__acknowledge_no_fever:
+  utter_daily_ci_feel_worse_acknowledge_no_fever:
     - text: OK, I'm taking note that you don't have a fever today
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing:
     - text: And are you experiencing shortness of breath or difficulty breathing?
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing_error:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing___still:
+    - text: And are you still experiencing shortness of breath or difficulty breathing?
+
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing_error:
     - text: Sorry, please tell me if you have shortness of breath or difficulty breathing
       buttons:
         - title: Yes
@@ -914,13 +917,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__acknowledge_no_diff_breathing:
+  utter_daily_ci_feel_worse_acknowledge_no_diff_breathing:
     - text: That's good
 
-  utter_ask_daily_ci__feel_worse__has_cough:
+  utter_ask_daily_ci_feel_worse_form_has_cough:
     - text: Do you have a cough?
 
-  utter_ask_daily_ci__feel_worse__has_cough_error:
+  utter_ask_daily_ci_feel_worse_form_has_cough___still:
+    - text: Do you still have a cough?
+
+  utter_ask_daily_ci_feel_worse_form_has_cough_error:
     - text: Sorry, please tell me if you have a cough or not
       buttons:
         - title: Yes
@@ -931,13 +937,13 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__no_cough_recommendation:
+  utter_daily_ci_feel_worse_no_cough_recommendation:
     - text: But since you're still feeling sick, you should keep staying isolated and continue to rest
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing_worsened:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing_worsened:
     - text: Has this worsened since yesterday?
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing_worsened_error:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing_worsened_error:
     - text: Sorry, have these symptoms worsened since yesterday?
       buttons:
         - title: Yes
@@ -948,24 +954,27 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__diff_breathing_worsened_recommendation_1:
+  utter_daily_ci_feel_worse_diff_breathing_worsened_recommendation_1:
     - text: You may want to discuss your situation with your doctor, if that's possible, or call {provincial_811}
 
-  utter_daily_ci__feel_worse__diff_breathing_worsened_recommendation_2:
+  utter_daily_ci_feel_worse_diff_breathing_worsened_recommendation_2:
     - text: If your symptoms worsen, you will need to get to the nearest emergency department or call 911
 
-  utter_daily_ci__feel_worse__diff_breathing_not_worsened_recommendation_1:
+  utter_daily_ci_feel_worse_diff_breathing_not_worsened_recommendation_1:
     - text: OK, if this gets worse, you should call your doctor, if that's possible, or call {provincial_811} to discuss your situation with a nurse
 
-  utter_daily_ci__feel_worse__diff_breathing_not_worsened_recommendation_2:
+  utter_daily_ci_feel_worse_diff_breathing_not_worsened_recommendation_2:
     - text: In any case, make sure you keep staying isolated and continue to rest
 
   ## Daily check-in - feel no change
 
-  utter_ask_daily_ci__feel_no_change__has_fever:
+  utter_ask_daily_ci_feel_no_change_form_has_fever:
     - text: And is your temperature higher than 38°C or 100.4°F? (You can take your temperature now if you're not sure)
 
-  utter_ask_daily_ci__feel_no_change__has_fever_error:
+  utter_ask_daily_ci_feel_no_change_form_has_fever___still:
+    - text: And is your temperature still higher than 38°C or 100.4°F? (You can take your temperature now if you're not sure)
+
+  utter_ask_daily_ci_feel_no_change_form_has_fever_error:
     - text: Sorry, is your temperature higher than 38C or 100.4F?
       buttons:
         - title: Yes
@@ -976,13 +985,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_no_change__acknowledge_no_fever:
+  utter_daily_ci_feel_no_change_form_acknowledge_no_fever:
     - text: That's good, I'm taking note that you don't have a fever today
 
-  utter_ask_daily_ci__feel_no_change__has_cough:
+  utter_ask_daily_ci_feel_no_change_form_has_cough:
     - text: Do you have a cough?
 
-  utter_ask_daily_ci__feel_no_change__has_cough_error:
+  utter_ask_daily_ci_feel_no_change_form_has_cough___still:
+    - text: Do you still have a cough?
+
+  utter_ask_daily_ci_feel_no_change_form_has_cough_error:
     - text: Sorry, please tell me if you have a cough or not
       buttons:
         - title: Yes
@@ -993,10 +1005,10 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_no_change__has_diff_breathing:
+  utter_ask_daily_ci_feel_no_change_form_has_diff_breathing:
     - text: Do you still have shortness of breath or difficulty breathing?
 
-  utter_ask_daily_ci__feel_no_change__has_diff_breathing_error:
+  utter_ask_daily_ci_feel_no_change_form_has_diff_breathing_error:
     - text: Sorry, please tell me if you still have shortness of breath or difficulty breathing
       buttons:
         - title: Yes
@@ -1007,30 +1019,30 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_no_change__acknowledge_diff_breathing:
+  utter_daily_ci_feel_no_change_form_acknowledge_diff_breathing:
     - text: I'm sorry to see that
 
-  utter_daily_ci__feel_no_change__diff_breathing_recommendation:
+  utter_daily_ci_feel_no_change_form_diff_breathing_recommendation:
     - text: "If your symptoms worsen, you may need to go to the ER. If you need assistance, you should:\n- Contact your family doctor if possible, or\n- Call {provincial_811} for assistance\nAnd make sure you inform them of your condition"
 
-  utter_daily_ci__feel_no_change__acknowledge_no_diff_breathing:
+  utter_daily_ci_feel_no_change_form_acknowledge_no_diff_breathing:
     - text: That's good, I'm glad to hear that
 
-  utter_daily_ci__feel_no_change__no_diff_breathing_recommendation:
+  utter_daily_ci_feel_no_change_form_no_diff_breathing_recommendation:
     - text: You should continue to rest, stay isolated and monitor your symptoms for any change
 
-  utter_daily_ci__feel_no_change__mild_last_symptoms_recommendation:
+  utter_daily_ci_feel_no_change_form_mild_last_symptoms_recommendation:
     - text: Since you still feel sick, you should stay isolated, rest and continue monitoring your symptoms
 
   ## Daily check-in - feel better
 
-  utter_daily_ci__feel_better__acknowledge:
+  utter_daily_ci_feel_better_acknowledge:
     - text: I'm glad to know you're feeling better
 
-  utter_ask_daily_ci__feel_better__has_fever:
+  utter_ask_daily_ci_feel_better_form_has_fever:
     - text: Now, is your temperature higher than 38°C or 100.4°F? (You can take your temperature now if you're not sure)
 
-  utter_ask_daily_ci__feel_better__has_fever_error:
+  utter_ask_daily_ci_feel_better_form_has_fever_error:
     - text: Sorry, is your temperature higher than 38C or 100.4F?
       buttons:
         - title: Yes
@@ -1041,13 +1053,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_better__acknowledge_no_fever:
+  utter_daily_ci_feel_better_acknowledge_no_fever:
     - text: That's good, I'm taking note that you don't have a fever today
 
-  utter_ask_daily_ci__feel_better__has_cough:
+  utter_ask_daily_ci_feel_better_form_has_cough:
     - text: Do you have a cough?
 
-  utter_ask_daily_ci__feel_better__has_cough_error:
+  utter_ask_daily_ci_feel_better_form_has_cough___still:
+    - text: Do you still have a cough?
+
+  utter_ask_daily_ci_feel_better_form_has_cough_error:
     - text: Sorry, please tell me if you have a cough or not
       buttons:
         - title: Yes
@@ -1058,10 +1073,10 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_better__has_diff_breathing:
+  utter_ask_daily_ci_feel_better_form_has_diff_breathing:
     - text: Do you still have other symptoms, like shortness of breath or some difficulty breathing?
 
-  utter_ask_daily_ci__feel_better__has_diff_breathing_error:
+  utter_ask_daily_ci_feel_better_form_has_diff_breathing_error:
     - text: Sorry, please tell me if you still have shortness of breath or some difficulty breathing
       buttons:
         - title: Yes
@@ -1072,13 +1087,13 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_better__has_other_mild_symptoms_with_acknowledge:
+  utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms___with_acknowledge:
     - text: Good, and do you still have symptoms like fatigue or sore throat?
 
-  utter_ask_daily_ci__feel_better__has_other_mild_symptoms:
+  utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms:
     - text: Do you still have other symptoms, like fatigue or sore throat?
 
-  utter_ask_daily_ci__feel_better__has_other_mild_symptoms_error:
+  utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms_error:
     - text: Sorry, please tell me if you still have symptoms such as fatigue or sore throat
       buttons:
         - title: Yes
@@ -1089,10 +1104,10 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_better__is_symptom_free:
+  utter_ask_daily_ci_feel_better_form_is_symptom_free:
     - text: Great, would you say that you have completely recovered from the virus?
 
-  utter_ask_daily_ci__feel_better__is_symptom_free_error:
+  utter_ask_daily_ci_feel_better_form_is_symptom_free_error:
     - text: Sorry, have you completely recovered from the virus or are you still a little sick?
       buttons:
         - title: Yes I have recovered
@@ -1103,17 +1118,17 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_better__breathing_difficulty_recommendation_1:
+  utter_daily_ci_feel_better_breathing_difficulty_recommendation_1:
     - text: Sorry about that. If this gets worse, I recommend that you contact your doctor or call {provincial_811} to discuss your symptoms
 
-  utter_daily_ci__feel_better__breathing_difficulty_recommendation_2:
+  utter_daily_ci_feel_better_breathing_difficulty_recommendation_2:
     - text: Since you are still sick, you should stay isolated, rest, and continue monitoring your symptoms
 
-  utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation:
+  utter_daily_ci_feel_better_form_has_other_mild_symptoms_recommendation:
     - text: OK, since you still have some symptoms, I recommend that you stay isolated and that you continue to rest
 
-  ? utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation
-  : - text: OK, since you still feel sick, I recommend that you stay isolated and that you continue to rest
+  utter_daily_ci_feel_better_form_has_other_mild_symptoms_still_sick_recommendation:
+    - text: OK, since you still feel sick, I recommend that you stay isolated and that you continue to rest
 
   utter_daily_checkin_validation_code:
     - text: "Hi {first_name}, this is the validation code for your daily check-in enrollment: {validation_code}. If you did not request to enroll in the daily check-in, please ignore this text message"

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -594,8 +594,7 @@ responses:
     - text: "Je peux répondre à vos questions sur une variété de sujets entourant la Covid-19"
 
   utter_qa_disclaimer:
-    - text:
-        "Veuillez noter que pour le moment, je suis en mesure de répondre à un
+    - text: "Veuillez noter que pour le moment, je suis en mesure de répondre à un
         nombre limité de questions, mais je m'améliore constamment et j'apprends
         à l'aide des questions que vous me posez"
 
@@ -612,8 +611,7 @@ responses:
   utter_qa_sample_contagion:
     - text: "Si nous avons Covid-19, combien de temp sommes-nous contagieux?"
     - text: "Combien de temps sommes-nous contagieux quand nous avons Covid-19?"
-    - text:
-        "Après la disparition des symptômes, combien de temps une personne reste
+    - text: "Après la disparition des symptômes, combien de temps une personne reste
         contagieuse?"
     - text: "Combien de temps une personne est-elle contagieuse?"
     - text: "Suis-je contagieux longtemps après que j'ai contracté le virus?"
@@ -623,11 +621,9 @@ responses:
     - text: "Combien de temp le virus vit-il sur des surfaces?"
     - text: "Pour combien de temps COVID19 peut rester en vie sur des surfaces
         différentes?"
-    - text:
-        "Est-il vrai que Covid-19 peut survivre jusqu'à quelques jours sur les
+    - text: "Est-il vrai que Covid-19 peut survivre jusqu'à quelques jours sur les
         surfaces dures?"
-    - text:
-        "Combien de temps le virus survit-il sur une surface comme une poignée
+    - text: "Combien de temps le virus survit-il sur une surface comme une poignée
         de porte?"
     - text: "Combien de temps est-ce que la Covid 19 peut rester sur des surfaces?"
 
@@ -707,8 +703,7 @@ responses:
     - text: "Combien de cas au Québec?"
     - text: "Combien de personnes sont infectées au Québec?"
     - text: "Combien de cas sont aux États-Unis?"
-    - text:
-        "De la population infectée dans le monde entier quel sera le rapport des
+    - text: "De la population infectée dans le monde entier quel sera le rapport des
         personnes asymptomatiques?"
 
   utter_ask_active_question:
@@ -877,10 +872,10 @@ responses:
 
   ## Daily check-in - feel worse
 
-  utter_ask_daily_ci__feel_worse__severe_symptoms:
+  utter_ask_daily_ci_feel_worse_form_severe_symptoms:
     - text: "Avez-vous un ou plusieurs des symptômes suivants: des difficultés respiratoires graves, de fortes douleurs à la poitrine, beaucoup de mal à vous réveiller, de la confusion ou des pertes de conscience?"
 
-  utter_ask_daily_ci__feel_worse__severe_symptoms_error:
+  utter_ask_daily_ci_feel_worse_form_severe_symptoms_error:
     - text: "Désolée, avez-vous un ou plusieurs des symptômes suivants:\n- Difficultés respiratoires graves\n- De fortes douleurs à la poitrine\n- Beaucoup de mal à se réveiller\n- Confusion\n- Perte de conscience"
       buttons:
         - title: Oui
@@ -891,13 +886,13 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__acknowledge_no_severe_symptoms:
+  utter_daily_ci_feel_worse_acknowledge_no_severe_symptoms:
     - text: D'accord, voyons voir vos symptômes
 
-  utter_ask_daily_ci__feel_worse__has_fever:
+  utter_ask_daily_ci_feel_worse_form_has_fever:
     - text: Est-ce que vous faites de la fièvre? (plus de 38°C or 100.4°F) (Prenez votre température si vous ne savez pas)
 
-  utter_ask_daily_ci__feel_worse__has_fever_error:
+  utter_ask_daily_ci_feel_worse_form_has_fever_error:
     - text: Désolée, est-ce que votre température est plus élevée que 38C ou 100,4F?
       buttons:
         - title: Oui
@@ -908,13 +903,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__acknowledge_no_fever:
+  utter_daily_ci_feel_worse_acknowledge_no_fever:
     - text: D'accord, je note que vous ne faites pas de fièvre aujourd'hui
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing:
     - text: Avez-vous de l'essoufflement ou de la difficulté à respirer?
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing_error:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing___still:
+    - text: Avez-vous encore de l'essoufflement ou de la difficulté à respirer?
+
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing_error:
     - text: Désolée, dites-moi si vous avez de l'essoufflement ou de la difficulté à respirer
       buttons:
         - title: Oui
@@ -925,13 +923,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__acknowledge_no_diff_breathing:
+  utter_daily_ci_feel_worse_acknowledge_no_diff_breathing:
     - text: Tant mieux
 
-  utter_ask_daily_ci__feel_worse__has_cough:
+  utter_ask_daily_ci_feel_worse_form_has_cough:
     - text: Est-ce que vous toussez?
 
-  utter_ask_daily_ci__feel_worse__has_cough_error:
+  utter_ask_daily_ci_feel_worse_form_has_cough___still:
+    - text: Est-ce que vous toussez encore?
+
+  utter_ask_daily_ci_feel_worse_form_has_cough_error:
     - text: Désolée, dites-moi si vous toussez aujourd'hui
       buttons:
         - title: Oui
@@ -942,13 +943,13 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__no_cough_recommendation:
+  utter_daily_ci_feel_worse_no_cough_recommendation:
     - text: Mais puisque vous vous sentez encore malade, je vous conseille de continuer à vous isoler et à vous reposer
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing_worsened:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing_worsened:
     - text: Est-ce que ça a empiré depuis hier?
 
-  utter_ask_daily_ci__feel_worse__has_diff_breathing_worsened_error:
+  utter_ask_daily_ci_feel_worse_form_has_diff_breathing_worsened_error:
     - text: Désolée, est-ce que ces symptômes ont empiré depuis hier?
       buttons:
         - title: Oui
@@ -959,24 +960,27 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_worse__diff_breathing_worsened_recommendation_1:
+  utter_daily_ci_feel_worse_diff_breathing_worsened_recommendation_1:
     - text: Vous devriez peut-être en discuter avec votre médecin, si c'est possible, ou appeler au {provincial_811}
 
-  utter_daily_ci__feel_worse__diff_breathing_worsened_recommendation_2:
+  utter_daily_ci_feel_worse_diff_breathing_worsened_recommendation_2:
     - text: Si vos symptômes empirent, vous pourriez devoir vous rendre à l'urgence ou appeler le 911
 
-  utter_daily_ci__feel_worse__diff_breathing_not_worsened_recommendation_1:
+  utter_daily_ci_feel_worse_diff_breathing_not_worsened_recommendation_1:
     - text: C’est noté. Si cela empire, je vous conseille de contacter votre médecin, si possible, ou d'appeler le {provincial_811} pour discuter de vos symptômes
 
-  utter_daily_ci__feel_worse__diff_breathing_not_worsened_recommendation_2:
+  utter_daily_ci_feel_worse_diff_breathing_not_worsened_recommendation_2:
     - text: Dans tous les cas, assurez-vous de continuer à vous isoler et à vous reposer
 
   ## Daily check-in - feel no change
 
-  utter_ask_daily_ci__feel_no_change__has_fever:
+  utter_ask_daily_ci_feel_no_change_form_has_fever:
     - text: Et est-ce que vous faites de la fièvre? (plus de 38°C ou 100,4°F) (Prenez votre température si vous ne le savez pas)
 
-  utter_ask_daily_ci__feel_no_change__has_fever_error:
+  utter_ask_daily_ci_feel_no_change_form_has_fever___still:
+    - text: Et est-ce que vous faites encore de la fièvre? (plus de 38°C ou 100,4°F) (Prenez votre température si vous ne le savez pas)
+
+  utter_ask_daily_ci_feel_no_change_form_has_fever_error:
     - text: Désolée, est-ce que votre température est plus élevée que 38C ou 100,4F?
       buttons:
         - title: Oui
@@ -987,13 +991,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_no_change__acknowledge_no_fever:
+  utter_daily_ci_feel_no_change_form_acknowledge_no_fever:
     - text: Très bien, je note que vous ne faites pas de fièvre aujourd'hui
 
-  utter_ask_daily_ci__feel_no_change__has_cough:
+  utter_ask_daily_ci_feel_no_change_form_has_cough:
     - text: Est-ce que vous toussez?
 
-  utter_ask_daily_ci__feel_no_change__has_cough_error:
+  utter_ask_daily_ci_feel_no_change_form_has_cough___still:
+    - text: Est-ce que vous toussez encore?
+
+  utter_ask_daily_ci_feel_no_change_form_has_cough_error:
     - text: Désolée, dites-moi si vous toussez aujourd'hui
       buttons:
         - title: Oui
@@ -1004,10 +1011,10 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_no_change__has_diff_breathing:
+  utter_ask_daily_ci_feel_no_change_form_has_diff_breathing:
     - text: Avez-vous encore de l'essoufflement ou de la difficulté à respirer?
 
-  utter_ask_daily_ci__feel_no_change__has_diff_breathing_error:
+  utter_ask_daily_ci_feel_no_change_form_has_diff_breathing_error:
     - text: Désolée, dites-moi si vous avez encore de l'essoufflement ou de la difficulté à respirer
       buttons:
         - title: Oui
@@ -1018,30 +1025,30 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_no_change__acknowledge_diff_breathing:
+  utter_daily_ci_feel_no_change_form_acknowledge_diff_breathing:
     - text: Je suis désolée que ce soit encore le cas
 
-  utter_daily_ci__feel_no_change__diff_breathing_recommendation:
+  utter_daily_ci_feel_no_change_form_diff_breathing_recommendation:
     - text: "Si vos symptômes empirent, vous pourriez devoir vous rendre à l'urgence. Pour de l'assistance, vous devriez: \n- Soit appeler votre médecin de famille, si c'est possible, ou \n- Appeler au {provincial_811}\n Et assurez-vous de fournir les informations sur votre condition"
 
-  utter_daily_ci__feel_no_change__acknowledge_no_diff_breathing:
+  utter_daily_ci_feel_no_change_form_acknowledge_no_diff_breathing:
     - text: Bonne nouvelle, je suis heureuse de l'apprendre
 
-  utter_daily_ci__feel_no_change__no_diff_breathing_recommendation:
+  utter_daily_ci_feel_no_change_form_no_diff_breathing_recommendation:
     - text: Je vous conseille de continuer à vous reposer, à vous isoler et à surveiller vos symptômes
 
-  utter_daily_ci__feel_no_change__mild_last_symptoms_recommendation:
+  utter_daily_ci_feel_no_change_form_mild_last_symptoms_recommendation:
     - text: Puisque vous êtes encore malade, je vous conseille de continuer à vous reposer, à vous isoler et à surveiller vos symptômes
 
   ## Daily check-in - feel better
 
-  utter_daily_ci__feel_better__acknowledge:
+  utter_daily_ci_feel_better_acknowledge:
     - text: Je suis heureuse d'apprendre que vous allez mieux
 
-  utter_ask_daily_ci__feel_better__has_fever:
+  utter_ask_daily_ci_feel_better_form_has_fever:
     - text: Est-ce que vous faites de la fièvre? (plus de 38°C ou 100,4°F) (Prenez votre température si vous ne savez pas)
 
-  utter_ask_daily_ci__feel_better__has_fever_error:
+  utter_ask_daily_ci_feel_better_form_has_fever_error:
     - text: Désolée, est-ce que votre température est plus élevée que 38C ou 100,4F?
       buttons:
         - title: Oui
@@ -1052,13 +1059,16 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_better__acknowledge_no_fever:
+  utter_daily_ci_feel_better_acknowledge_no_fever:
     - text: Très bien, je note que vous ne faites pas de fièvre aujourd'hui
 
-  utter_ask_daily_ci__feel_better__has_cough:
+  utter_ask_daily_ci_feel_better_form_has_cough:
     - text: Est-ce que vous toussez?
 
-  utter_ask_daily_ci__feel_better__has_cough_error:
+  utter_ask_daily_ci_feel_better_form_has_cough___still:
+    - text: Est-ce que vous toussez encore?
+
+  utter_ask_daily_ci_feel_better_form_has_cough_error:
     - text: Désolée, dites-moi si vous toussez aujourd'hui
       buttons:
         - title: Oui
@@ -1069,13 +1079,10 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_better__has_diff_breathing:
+  utter_ask_daily_ci_feel_better_form_has_diff_breathing:
     - text: Avez-vous encore d'autres symptômes, comme de l'essoufflement ou de la difficulté à respirer?
 
-  utter_ask_daily_ci__feel_better__has_other_mild_symptoms_with_acknowledge:
-    - text: Très bien, et avez-vous encore d'autres symptômes, comme des maux de gorge ou de la fatigue inhabituelle?
-
-  utter_ask_daily_ci__feel_better__has_diff_breathing_error:
+  utter_ask_daily_ci_feel_better_form_has_diff_breathing_error:
     - text: Désolée, dites-moi si vous avez encore d'autres symptômes comme de l'essoufflement ou de la difficulté à respirer
       buttons:
         - title: Oui
@@ -1086,10 +1093,13 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_better__has_other_mild_symptoms:
+  utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms:
     - text: Avez-vous encore d'autres symptômes, comme des maux de gorge ou de la fatigue inhabituelle?
 
-  utter_ask_daily_ci__feel_better__has_other_mild_symptoms_error:
+  utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms___with_acknowledge:
+    - text: Très bien, et avez-vous encore d'autres symptômes, comme des maux de gorge ou de la fatigue inhabituelle?
+
+  utter_ask_daily_ci_feel_better_form_has_other_mild_symptoms_error:
     - text: Désolée, dites-moi si vous avez encore d'autres symptômes comme des maux de gorge ou de la fatigue inhabituelle
       buttons:
         - title: Oui
@@ -1100,10 +1110,10 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_ask_daily_ci__feel_better__is_symptom_free:
+  utter_ask_daily_ci_feel_better_form_is_symptom_free:
     - text: Bonne nouvelle! Diriez-vous que vous êtes tout à fait guéri(e)?
 
-  utter_ask_daily_ci__feel_better__is_symptom_free_error:
+  utter_ask_daily_ci_feel_better_form_is_symptom_free_error:
     - text: Désolée, vous sentez-vous tout à fait guéri(e) ou êtes-vous encore un peu malade?
       buttons:
         - title: Oui tout à fait guéri(e)
@@ -1114,17 +1124,17 @@ responses:
         data:
           disableTextField: "true"
 
-  utter_daily_ci__feel_better__breathing_difficulty_recommendation_1:
+  utter_daily_ci_feel_better_breathing_difficulty_recommendation_1:
     - text: Désolée de l'apprendre. Si cela empire, je vous conseille de contacter votre médecin, si c'est possible, ou d'appeler le {provincial_811} pour discuter de vos symptômes
 
-  utter_daily_ci__feel_better__breathing_difficulty_recommendation_2:
+  utter_daily_ci_feel_better_breathing_difficulty_recommendation_2:
     - text: Puisque vous êtes encore malade, je vous conseille de continuer à vous isoler et à vous reposer
 
-  utter_daily_ci__feel_better__has_other_mild_symptoms_recommendation:
+  utter_daily_ci_feel_better_form_has_other_mild_symptoms_recommendation:
     - text: D'accord. Puisque vous avez encore certains symptômes, je vous conseille de continuer à vous isoler et à vous reposer
 
-  ? utter_daily_ci__feel_better__has_other_mild_symptoms_still_sick_recommendation
-  : - text: C'est noté. Puisque vous êtes encore malade, je vous conseille de continuer à vous isoler et à vous reposer
+  utter_daily_ci_feel_better_form_has_other_mild_symptoms_still_sick_recommendation:
+    - text: C'est noté. Puisque vous êtes encore malade, je vous conseille de continuer à vous isoler et à vous reposer
 
   utter_daily_checkin_validation_code:
     - text: "Bonjour {first_name}, voici le code de validation pour l’inscription au suivi quotidien : {validation_code}. Si vous n’avez pas demandé à vous inscrire au suivi quotidien, veuillez ignorer ce message"

--- a/integration-tests-en/interactions/bot/daily_ci/feel_better/ask_cough_fever.jinja
+++ b/integration-tests-en/interactions/bot/daily_ci/feel_better/ask_cough_fever.jinja
@@ -11,6 +11,6 @@
         "text": "But you should *avoid taking ibuprofen* (such as Advil or Motrin), as it might have unwanted effects"
     },
     {
-        "text": "Do you have a cough?"
+        "text": "Do you still have a cough?"
     }
 ]

--- a/integration-tests-en/interactions/bot/daily_ci/feel_no_change/ask_cough_fever.jinja
+++ b/integration-tests-en/interactions/bot/daily_ci/feel_no_change/ask_cough_fever.jinja
@@ -11,6 +11,6 @@
         "text": "But you should *avoid taking ibuprofen* (such as Advil or Motrin), as it might have unwanted effects"
     },
     {
-        "text": "Do you have a cough?"
+        "text": "Do you still have a cough?"
     }
 ]

--- a/integration-tests-en/interactions/bot/daily_ci/feel_no_change/ask_fever_still.jinja
+++ b/integration-tests-en/interactions/bot/daily_ci/feel_no_change/ask_fever_still.jinja
@@ -1,0 +1,7 @@
+{% import 'bot/macros.jinja' as bot %}
+
+[
+    {
+        "text": "And is your temperature still higher than 38°C or 100.4°F? (You can take your temperature now if you're not sure)"
+    }
+]

--- a/integration-tests-en/scenarios/daily_ci/feel_no_change_moderate_symptoms_with_error.yml
+++ b/integration-tests-en/scenarios/daily_ci/feel_no_change_moderate_symptoms_with_error.yml
@@ -5,7 +5,7 @@
 - user: invalid_input
   bot: daily_ci/ask_feel_error
 - user: daily_ci/no_change
-  bot: daily_ci/feel_no_change/ask_fever
+  bot: daily_ci/feel_no_change/ask_fever_still
 - user: affirm
   bot: daily_ci/feel_no_change/ask_cough_fever
 - user: affirm


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
Content of the forms remains approximately the same, except the submit part, which I got out in one action for the three of them, and the setting of the "feel_worse" slot, for which I created one action to set it true. It probably won't be necessary when the rest will be refactored.

I also applied the "still" variations, which were omitted in the original version, and renamed lots of messages to fit the rasa convention to fetch some of them automatically. All the messages should be renamed but that's another issue
## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
closes #30 
## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * #{pr-number}  -->

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
